### PR TITLE
docs(skills): document installing the skill with library-skills

### DIFF
--- a/docs/getting_started/agent_skills.md
+++ b/docs/getting_started/agent_skills.md
@@ -60,27 +60,18 @@ one CLI wires them into any project that depends on them. OpenRetailScience ship
 that layout already, so the tool needs no extra configuration:
 
 ```bash
-uvx library-skills --claude
+uvx library-skills
 ```
 
 It reads your project's dependencies, finds `using-openretailscience` inside the
 installed package, and offers to symlink it into `.agents/skills/`. The `--claude`
 flag adds `.claude/skills/`, which Claude Code needs because it does not read
 `.agents`. Run the command again after your dependencies change and it repairs
-stale links. `uvx library-skills --check` reports drift without touching anything,
-so it works as a CI step, and `--copy` writes real files where symlinks are
-unavailable. The command asks before it installs anything; `--all --yes` answers
-those prompts for you when you are scripting the setup.
+stale links; `--copy` writes real files where symlinks are unavailable.
 
-Both installers write the same relative symlink, so the note above about keeping
-these out of source control applies to the CLI too. The CLI's own docs suggest
-committing them, which holds only when everyone keeps the environment at the same
-path, on the same Python minor version and platform: all three sit in the link
-(`../../.venv/lib/python3.11/site-packages/...`).
-
-Either route installs the same skill folder, so use whichever suits your project.
-`install_skills()` is still the one to reach for on Databricks, or when you want
-the skill available to every project instead of one.
+It asks before installing anything. Name the skill to script that away:
+`uvx library-skills -s using-openretailscience -y`. `--all` also skips the
+prompt, but it takes every skill in your dependency tree, transitive ones included.
 
 ## Databricks
 

--- a/docs/getting_started/agent_skills.md
+++ b/docs/getting_started/agent_skills.md
@@ -71,8 +71,15 @@ so it works as a CI step, and `--copy` writes real files where symlinks are
 unavailable.
 
 The links it creates are relative to the project rather than absolute paths into a
-virtual environment, so you can commit these, provided everyone installs into a
-repo-local `.venv`.
+virtual environment:
+
+```text
+.agents/skills/using-openretailscience
+  -> ../../.venv/lib/python3.11/site-packages/openretailscience/.agents/skills/using-openretailscience
+```
+
+So unlike the ones `install_skills()` writes, you can commit these, provided
+everyone installs into a repo-local `.venv`.
 
 Either route installs the same skill folder, so use whichever suits your project.
 `install_skills()` is still the one to reach for on Databricks, or when you want

--- a/docs/getting_started/agent_skills.md
+++ b/docs/getting_started/agent_skills.md
@@ -69,7 +69,8 @@ flag adds `.claude/skills/`, which Claude Code needs because it does not read
 `.agents`. Run the command again after your dependencies change and it repairs
 stale links. `uvx library-skills --check` reports drift without touching anything,
 so it works as a CI step, and `--copy` writes real files where symlinks are
-unavailable.
+unavailable. The command asks before it installs anything; `--all --yes` answers
+those prompts for you when you are scripting the setup.
 
 The links it creates are relative to the project rather than absolute paths into a
 virtual environment:
@@ -79,8 +80,11 @@ virtual environment:
   -> ../../.venv/lib/python3.11/site-packages/openretailscience/.agents/skills/using-openretailscience
 ```
 
-So unlike the ones `install_skills()` writes, you can commit these, provided
-everyone installs into a repo-local `.venv`.
+So unlike the ones `install_skills()` writes, you can commit these, as long as
+everyone builds a repo-local `.venv`. The path also carries the Python minor
+version and the platform's own layout, so a link committed under `python3.11`
+breaks for anyone on 3.12, or on Windows, where the directory is
+`.venv\Lib\site-packages`.
 
 Either route installs the same skill folder, so use whichever suits your project.
 `install_skills()` is still the one to reach for on Databricks, or when you want

--- a/docs/getting_started/agent_skills.md
+++ b/docs/getting_started/agent_skills.md
@@ -69,8 +69,8 @@ flag adds `.claude/skills/`, which Claude Code needs because it does not read
 `.agents`. Run the command again after your dependencies change and it repairs
 stale links; `--copy` writes real files where symlinks are unavailable.
 
-It asks before installing anything. To script it, name the skill and skip the
-prompts: `uvx library-skills -s using-openretailscience -y`.
+The command prompts for what to install, so a scripted setup names the skill and
+skips the prompts: `uvx library-skills -s using-openretailscience -y`.
 
 ## Databricks
 

--- a/docs/getting_started/agent_skills.md
+++ b/docs/getting_started/agent_skills.md
@@ -72,19 +72,11 @@ so it works as a CI step, and `--copy` writes real files where symlinks are
 unavailable. The command asks before it installs anything; `--all --yes` answers
 those prompts for you when you are scripting the setup.
 
-The links it creates are relative to the project rather than absolute paths into a
-virtual environment:
-
-```text
-.agents/skills/using-openretailscience
-  -> ../../.venv/lib/python3.11/site-packages/openretailscience/.agents/skills/using-openretailscience
-```
-
-So unlike the ones `install_skills()` writes, you can commit these, as long as
-everyone builds a repo-local `.venv`. The path also carries the Python minor
-version and the platform's own layout, so a link committed under `python3.11`
-breaks for anyone on 3.12, or on Windows, where the directory is
-`.venv\Lib\site-packages`.
+Both installers write the same relative symlink, so the note above about keeping
+these out of source control applies to the CLI too. The CLI's own docs suggest
+committing them, which holds only when everyone keeps the environment at the same
+path, on the same Python minor version and platform: all three sit in the link
+(`../../.venv/lib/python3.11/site-packages/...`).
 
 Either route installs the same skill folder, so use whichever suits your project.
 `install_skills()` is still the one to reach for on Databricks, or when you want

--- a/docs/getting_started/agent_skills.md
+++ b/docs/getting_started/agent_skills.md
@@ -53,7 +53,8 @@ one left by an earlier install.
 
 ## Installing with the library-skills CLI
 
-The bundled skill also follows the [Library Skills](https://library-skills.io)
+The bundled skill also follows the
+[Library Skills](https://library-skills.io){target="_blank" rel="noopener"}
 convention: libraries publish their skills under `<package>/.agents/skills/`, and
 one CLI wires them into any project that depends on them. OpenRetailScience ships
 that layout already, so the tool needs no extra configuration:

--- a/docs/getting_started/agent_skills.md
+++ b/docs/getting_started/agent_skills.md
@@ -69,9 +69,8 @@ flag adds `.claude/skills/`, which Claude Code needs because it does not read
 `.agents`. Run the command again after your dependencies change and it repairs
 stale links; `--copy` writes real files where symlinks are unavailable.
 
-It asks before installing anything. Name the skill to script that away:
-`uvx library-skills -s using-openretailscience -y`. `--all` also skips the
-prompt, but it takes every skill in your dependency tree, transitive ones included.
+It asks before installing anything. To script it, name the skill and skip the
+prompts: `uvx library-skills -s using-openretailscience -y`.
 
 ## Databricks
 

--- a/docs/getting_started/agent_skills.md
+++ b/docs/getting_started/agent_skills.md
@@ -51,6 +51,33 @@ one left by an earlier install.
     installed skill paths (for example `.agents/skills/using-openretailscience/`)
     to your `.gitignore`.
 
+## Installing with the library-skills CLI
+
+The bundled skill also follows the [Library Skills](https://library-skills.io)
+convention: libraries publish their skills under `<package>/.agents/skills/`, and
+one CLI wires them into any project that depends on them. OpenRetailScience ships
+that layout already, so the tool needs no extra configuration:
+
+```bash
+uvx library-skills --claude
+```
+
+It reads your project's dependencies, finds `using-openretailscience` inside the
+installed package, and offers to symlink it into `.agents/skills/`. The `--claude`
+flag adds `.claude/skills/`, which Claude Code needs because it does not read
+`.agents`. Run the command again after your dependencies change and it repairs
+stale links. `uvx library-skills --check` reports drift without touching anything,
+so it works as a CI step, and `--copy` writes real files where symlinks are
+unavailable.
+
+The links it creates are relative to the project rather than absolute paths into a
+virtual environment, so you can commit these, provided everyone installs into a
+repo-local `.venv`.
+
+Either route installs the same skill folder, so use whichever suits your project.
+`install_skills()` is still the one to reach for on Databricks, or when you want
+the skill available to every project instead of one.
+
 ## Databricks
 
 Databricks works differently, and the default `install_skills()` adapts


### PR DESCRIPTION
Adds a section to `docs/getting_started/agent_skills.md` covering the [library-skills](https://library-skills.io) CLI as a second way to install the bundled skill.

No package changes are needed. The skill already sits at `openretailscience/.agents/skills/using-openretailscience/`, which is the layout the convention asks for, and `[tool.hatch.build] artifacts` keeps it in the wheel and sdist.

The section covers what the CLI does, the `--claude` flag (Claude Code does not read `.agents`), `--copy` where symlinks are not available, re-running it to repair stale links, and `-s using-openretailscience -y` for a scripted install.

### Verified against the real tool

Built the wheel, unpacked it into throwaway projects' `site-packages`, and ran the CLI with stdin closed so any prompt would fail loudly rather than silently pass.

| Invocation | Result |
| --- | --- |
| `uvx library-skills --check` | discovers `using-openretailscience` from the installed package |
| `uvx library-skills -s using-openretailscience -y` | installs that skill only, unattended, with a second skill-shipping package present and untouched |
| `uvx library-skills -y` (no `-s`) | installs nothing: status `new`, "No changes needed" |
| re-run over a stale managed link | `Repaired: using-openretailscience` |

The installed link:

```
.agents/skills/using-openretailscience
  -> ../../.venv/lib/python3.11/site-packages/openretailscience/.agents/skills/using-openretailscience
```

The `target="_blank"` on the Library Skills link was checked by building a Material site with this repo's `markdown_extensions` block; `attr_list` (`mkdocs.yml:139`) carries the attributes through to the anchor.

### Corrections made during review

- An earlier draft claimed the CLI writes relative symlinks while `install_skills()` writes absolute ones, making only the CLI's links committable. That is wrong: `_relative_symlink_target()` (`openretailscience/skills.py:172`) uses `os.path.relpath`, so both installers produce byte-identical targets. The paragraph built on that distinction was removed.
- An earlier draft suggested `--all --yes` for a scripted install. `--all` bypasses the direct-dependency filter and takes every skill in the tree, transitive ones included, so the docs now name the skill explicitly instead.

### Left alone

The convention recommends naming a skill after its library (`fastapi`, `fastapi-development`), and ours is `using-openretailscience`. Discovery works regardless, and the CLI attributes the skill to the `openretailscience` package in its status table, so renaming would only churn existing installs.

Docs-only change; markdownlint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQQNs54AdunaH69TTcmfLu