### PR TITLE
Expand uv version constraint to support 0.12.x releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ artifacts = [ "openretailscience/.agents/**" ]
 
 [tool.uv]
 default-groups   = [ "dev", "docs", "examples" ]
-required-version = ">=0.10.0,<0.12.0"
+required-version = ">=0.10.0,<0.13.0"
 
 [tool.ruff]
 line-length    = 120


### PR DESCRIPTION
## Summary
Updates the `uv` package version constraint in `pyproject.toml` to allow version 0.12.x releases, expanding the upper bound from `<0.12.0` to `<0.13.0`.

## Changes
- Updated `tool.uv.required-version` from `>=0.10.0,<0.12.0` to `>=0.10.0,<0.13.0`

## Details
This change permits the use of uv 0.12.x versions while maintaining the minimum requirement of 0.10.0. The constraint continues to exclude version 0.13.0 and later, allowing for controlled adoption of newer uv releases.

https://claude.ai/code/session_01Vwn3FmTEyQMTkMYZyuLYPh