### PR TITLE
fix(plots): wrap over-tall outside legends into columns

### DIFF
--- a/openretailscience/.agents/skills/using-openretailscience/references/plotting.md
+++ b/openretailscience/.agents/skills/using-openretailscience/references/plotting.md
@@ -11,10 +11,9 @@ from openretailscience.plots import time, period_on_period, broken_timeline, pri
 
 Most `plot()` functions share these chrome keywords: `title`, `eyebrow`,
 `subtitle`, `source_text`, `x_label`, `y_label`, `ax`, `legend_title`,
-`move_legend_outside`. An outside legend taller than the plot area wraps into
-columns automatically, up to half the figure width; more series than that still
-overflow, so prefer a taller figure or `legend_style="end_of_line"` there. Pass
-`ax=` to draw onto one axes you manage. The chrome
+`move_legend_outside`. An outside legend too tall for the plot wraps into columns,
+up to half the figure width; past that prefer a taller figure or
+`legend_style="end_of_line"`. Pass `ax=` to draw onto one axes you manage. The chrome
 (title/eyebrow/subtitle/source) is figure-level (`fig.text` plus
 `fig.subplots_adjust`), so it does not compose with a `plt.subplots` grid: give
 each chart its own figure rather than tiling several into one. Only the

--- a/openretailscience/.agents/skills/using-openretailscience/references/plotting.md
+++ b/openretailscience/.agents/skills/using-openretailscience/references/plotting.md
@@ -12,8 +12,9 @@ from openretailscience.plots import time, period_on_period, broken_timeline, pri
 Most `plot()` functions share these chrome keywords: `title`, `eyebrow`,
 `subtitle`, `source_text`, `x_label`, `y_label`, `ax`, `legend_title`,
 `move_legend_outside`. An outside legend too tall for the plot wraps into columns,
-up to half the figure width; past that prefer a taller figure or
-`legend_style="end_of_line"`. Pass `ax=` to draw onto one axes you manage. The chrome
+up to half the figure width; past that it overflows, so prefer a taller figure — or,
+on the charts that take it, `legend_style="end_of_line"`. Pass `ax=` to draw onto one
+axes you manage. The chrome
 (title/eyebrow/subtitle/source) is figure-level (`fig.text` plus
 `fig.subplots_adjust`), so it does not compose with a `plt.subplots` grid: give
 each chart its own figure rather than tiling several into one. Only the

--- a/openretailscience/.agents/skills/using-openretailscience/references/plotting.md
+++ b/openretailscience/.agents/skills/using-openretailscience/references/plotting.md
@@ -11,7 +11,10 @@ from openretailscience.plots import time, period_on_period, broken_timeline, pri
 
 Most `plot()` functions share these chrome keywords: `title`, `eyebrow`,
 `subtitle`, `source_text`, `x_label`, `y_label`, `ax`, `legend_title`,
-`move_legend_outside`. Pass `ax=` to draw onto one axes you manage. The chrome
+`move_legend_outside`. An outside legend taller than the plot area wraps into
+columns automatically, up to half the figure width; more series than that still
+overflow, so prefer a taller figure or `legend_style="end_of_line"` there. Pass
+`ax=` to draw onto one axes you manage. The chrome
 (title/eyebrow/subtitle/source) is figure-level (`fig.text` plus
 `fig.subplots_adjust`), so it does not compose with a `plt.subplots` grid: give
 each chart its own figure rather than tiling several into one. Only the

--- a/openretailscience/plots/styles/styling_helpers.py
+++ b/openretailscience/plots/styles/styling_helpers.py
@@ -120,8 +120,7 @@ _CHROME_GAP_TITLE_TO_SUBTITLE_IN = 0.072
 _CHROME_GAP_HEADER_TO_AXES_IN = 0.108
 _CHROME_GAP_SOURCE_TO_AXES_IN = 0.15
 _CHROME_TOP_LABEL_HEADROOM_FACTOR = 1.2
-# A column-wrapped outside legend may claim at most this share of the figure width; the
-# axes keeps the rest. Beyond it, overflowing entries beat a plot squeezed to a sliver.
+# Past half the figure width, a few overflowing legend entries beat a plot squeezed to a sliver.
 _MAX_OUTSIDE_LEGEND_WIDTH_FRAC = 0.5
 
 END_OF_LINE_LEGEND_CONFLICT_MSG = (
@@ -887,21 +886,18 @@ def _style_legend(legend: Legend, title: str | None) -> None:
 def _fit_outside_legend(ax: Axes, title: str | None) -> None:
     """Wrap an over-tall outside legend into columns so it stays beside the plot.
 
-    An outside legend is pinned to the axes top and grows downward, so more entries than
-    the plot band holds spill past the axes bottom, across the chrome's source line and
-    eventually off the figure. Columns are added and re-measured until the stack fits the axes
-    height, capped at ``_MAX_OUTSIDE_LEGEND_WIDTH_FRAC`` of the figure width so widening the
-    legend never starves the axes. One that cannot fit within the cap is left as it is.
+    An outside legend is pinned to the axes top and grows downward, so more entries than the
+    plot band holds spill past the axes bottom, across the chrome's source line and eventually
+    off the figure. A legend still too tall at the width cap is left overflowing.
 
-    Runs after chrome, which sets both the final axes height and ``_ors_chrome_rect``; the
-    chrome reflow is repeated so ``tight_layout`` reserves the widened legend's slot.
+    Runs after chrome, which settles the axes height and sets ``_ors_chrome_rect``; the chrome
+    reflow is repeated so ``tight_layout`` reserves the widened legend's slot.
     """
     legend = ax.get_legend()
     fig = ax.figure
     renderer = _active_renderer(fig)
     axes_height = ax.get_window_extent(renderer=renderer).height
-    # Derived from the single-column width, so it under-counts how many columns the budget
-    # really holds (a column costs less than the first one, which carries the padding).
+    # An under-count: the first column carries the legend's padding, so later ones cost less.
     one_column_width = legend.get_window_extent(renderer=renderer).width
     max_cols = max(int(_MAX_OUTSIDE_LEGEND_WIDTH_FRAC * fig.bbox.width / one_column_width), 1)
     handles = list(legend.legend_handles)
@@ -1074,8 +1070,7 @@ def standard_graph_styles(  # noqa: PLR0913
         source_text=source_text,
     )
 
-    # Column-wrap the outside legend before auto-rotation, since both the fit and the
-    # rotation decision depend on the axes box chrome just settled.
+    # Before auto-rotation: widening the legend changes the axes width the rotation test reads.
     if legend_show and move_legend_outside:
         _fit_outside_legend(ax, legend_title)
 

--- a/openretailscience/plots/styles/styling_helpers.py
+++ b/openretailscience/plots/styles/styling_helpers.py
@@ -897,17 +897,20 @@ def _fit_outside_legend(ax: Axes, title: str | None) -> None:
     fig = ax.figure
     renderer = _active_renderer(fig)
     axes_height = ax.get_window_extent(renderer=renderer).height
-    # An under-count: the first column carries the legend's padding, so later ones cost less.
-    one_column_width = legend.get_window_extent(renderer=renderer).width
-    max_cols = max(int(_MAX_OUTSIDE_LEGEND_WIDTH_FRAC * fig.bbox.width / one_column_width), 1)
+    width_cap = _MAX_OUTSIDE_LEGEND_WIDTH_FRAC * fig.bbox.width
     handles = list(legend.legend_handles)
     labels = [text.get_text() for text in legend.get_texts()]
 
+    # Each candidate is measured rather than extrapolated from the single-column width: a column
+    # can cost more than the first one (its labels may be wider), so an estimate overshoots the cap.
     ncols = 1
-    while legend.get_window_extent(renderer=renderer).height > axes_height and ncols < max_cols:
-        ncols += 1
-        legend = _build_outside_legend(ax, handles, labels, ncols)
-        _style_legend(legend, title)
+    while legend.get_window_extent(renderer=renderer).height > axes_height and ncols < len(handles):
+        candidate = _build_outside_legend(ax, handles, labels, ncols + 1)
+        _style_legend(candidate, title)
+        if candidate.get_window_extent(renderer=renderer).width > width_cap:
+            _style_legend(_build_outside_legend(ax, handles, labels, ncols), title)
+            break
+        ncols, legend = ncols + 1, candidate
     if ncols == 1:
         return
 

--- a/openretailscience/plots/styles/styling_helpers.py
+++ b/openretailscience/plots/styles/styling_helpers.py
@@ -893,12 +893,10 @@ def _fit_outside_legend(ax: Axes, title: str | None) -> None:
     height, capped at ``_MAX_OUTSIDE_LEGEND_WIDTH_FRAC`` of the figure width so widening the
     legend never starves the axes. One that cannot fit within the cap is left as it is.
 
-    Runs after chrome, which sets the final axes height; the chrome reflow is repeated so
-    ``tight_layout`` reserves the widened legend's slot.
+    Runs after chrome, which sets both the final axes height and ``_ors_chrome_rect``; the
+    chrome reflow is repeated so ``tight_layout`` reserves the widened legend's slot.
     """
     legend = ax.get_legend()
-    if legend is None:
-        return
     fig = ax.figure
     renderer = _active_renderer(fig)
     axes_height = ax.get_window_extent(renderer=renderer).height
@@ -917,9 +915,8 @@ def _fit_outside_legend(ax: Axes, title: str | None) -> None:
     if ncols == 1:
         return
 
-    chrome_rect = getattr(fig, "_ors_chrome_rect", None)
-    if chrome_rect is not None:
-        _reflow_axes(fig, top=chrome_rect[0], bottom=chrome_rect[1])
+    chrome_top, chrome_bottom = fig._ors_chrome_rect
+    _reflow_axes(fig, top=chrome_top, bottom=chrome_bottom)
 
 
 def apply_legend(

--- a/openretailscience/plots/styles/styling_helpers.py
+++ b/openretailscience/plots/styles/styling_helpers.py
@@ -18,9 +18,11 @@ from openretailscience.plots.styles.graph_utils import draw_end_of_line_labels
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from matplotlib.artist import Artist
     from matplotlib.axes import Axes
     from matplotlib.backend_bases import RendererBase
     from matplotlib.figure import Figure
+    from matplotlib.legend import Legend
     from matplotlib.text import Text
 
 GridAxis = Literal["both", "x", "y", "none"]
@@ -118,6 +120,9 @@ _CHROME_GAP_TITLE_TO_SUBTITLE_IN = 0.072
 _CHROME_GAP_HEADER_TO_AXES_IN = 0.108
 _CHROME_GAP_SOURCE_TO_AXES_IN = 0.15
 _CHROME_TOP_LABEL_HEADROOM_FACTOR = 1.2
+# A column-wrapped outside legend may claim at most this share of the figure width; the
+# axes keeps the rest. Beyond it, overflowing entries beat a plot squeezed to a sliver.
+_MAX_OUTSIDE_LEGEND_WIDTH_FRAC = 0.5
 
 END_OF_LINE_LEGEND_CONFLICT_MSG = (
     "`move_legend_outside` and `legend_title` are ignored when legend_style='end_of_line'."
@@ -852,6 +857,71 @@ def apply_ticks(ax: Axes) -> None:
     _hide_zero_value_ticks(ax)
 
 
+def _build_outside_legend(ax: Axes, handles: list[Artist], labels: list[str], ncols: int) -> Legend:
+    """Build the legend anchored outside the axes, spread over ``ncols`` columns."""
+    style = PlotStyleHelper()
+    return ax.legend(
+        handles,
+        labels,
+        frameon=False,
+        bbox_to_anchor=style.legend_bbox_to_anchor,
+        loc=style.legend_loc,
+        ncols=ncols,
+    )
+
+
+def _style_legend(legend: Legend, title: str | None) -> None:
+    """Apply the configured legend font to ``legend``'s entries and optional ``title``."""
+    style = PlotStyleHelper()
+    legend_font_props = get_font_properties(style.legend_font)
+    if title is not None:
+        legend.set_title(title)
+        legend.get_title().set_fontproperties(legend_font_props)
+        legend.get_title().set_fontsize(style.legend_size)
+
+    for text in legend.get_texts():
+        text.set_fontproperties(legend_font_props)
+        text.set_fontsize(style.legend_size)
+
+
+def _fit_outside_legend(ax: Axes, title: str | None) -> None:
+    """Wrap an over-tall outside legend into columns so it stays beside the plot.
+
+    An outside legend is pinned to the axes top and grows downward, so more entries than
+    the plot band holds spill past the axes bottom, across the chrome's source line and
+    eventually off the figure. Columns are added and re-measured until the stack fits the axes
+    height, capped at ``_MAX_OUTSIDE_LEGEND_WIDTH_FRAC`` of the figure width so widening the
+    legend never starves the axes. One that cannot fit within the cap is left as it is.
+
+    Runs after chrome, which sets the final axes height; the chrome reflow is repeated so
+    ``tight_layout`` reserves the widened legend's slot.
+    """
+    legend = ax.get_legend()
+    if legend is None:
+        return
+    fig = ax.figure
+    renderer = _active_renderer(fig)
+    axes_height = ax.get_window_extent(renderer=renderer).height
+    # Derived from the single-column width, so it under-counts how many columns the budget
+    # really holds (a column costs less than the first one, which carries the padding).
+    one_column_width = legend.get_window_extent(renderer=renderer).width
+    max_cols = max(int(_MAX_OUTSIDE_LEGEND_WIDTH_FRAC * fig.bbox.width / one_column_width), 1)
+    handles = list(legend.legend_handles)
+    labels = [text.get_text() for text in legend.get_texts()]
+
+    ncols = 1
+    while legend.get_window_extent(renderer=renderer).height > axes_height and ncols < max_cols:
+        ncols += 1
+        legend = _build_outside_legend(ax, handles, labels, ncols)
+        _style_legend(legend, title)
+    if ncols == 1:
+        return
+
+    chrome_rect = getattr(fig, "_ors_chrome_rect", None)
+    if chrome_rect is not None:
+        _reflow_axes(fig, top=chrome_rect[0], bottom=chrome_rect[1])
+
+
 def apply_legend(
     ax: Axes,
     title: str | None = None,
@@ -880,7 +950,6 @@ def apply_legend(
         ValueError: If ``custom_labels`` is provided and its length does not
             match the number of legend handles on ``ax``.
     """
-    style = PlotStyleHelper()
     handles, labels = ax.get_legend_handles_labels()
     if reverse:
         handles = list(reversed(handles))
@@ -891,26 +960,10 @@ def apply_legend(
             raise ValueError(msg)
         labels = list(custom_labels)
 
-    if outside:
-        legend = ax.legend(
-            handles,
-            labels,
-            frameon=False,
-            bbox_to_anchor=style.legend_bbox_to_anchor,
-            loc=style.legend_loc,
-        )
-    else:
-        legend = ax.legend(handles, labels, frameon=False)
-
-    legend_font_props = get_font_properties(style.legend_font)
-    if title is not None:
-        legend.set_title(title)
-        legend.get_title().set_fontproperties(legend_font_props)
-        legend.get_title().set_fontsize(style.legend_size)
-
-    for text in legend.get_texts():
-        text.set_fontproperties(legend_font_props)
-        text.set_fontsize(style.legend_size)
+    legend = (
+        _build_outside_legend(ax, handles, labels, ncols=1) if outside else ax.legend(handles, labels, frameon=False)
+    )
+    _style_legend(legend, title)
 
 
 def standard_graph_styles(  # noqa: PLR0913
@@ -1023,6 +1076,11 @@ def standard_graph_styles(  # noqa: PLR0913
         subtitle=subtitle,
         source_text=source_text,
     )
+
+    # Column-wrap the outside legend before auto-rotation, since both the fit and the
+    # rotation decision depend on the axes box chrome just settled.
+    if legend_show and move_legend_outside:
+        _fit_outside_legend(ax, legend_title)
 
     # Auto-rotate AFTER chrome so the axes width reflects the final layout
     # (legend placement and chrome's tight_layout both shrink the axes).

--- a/openretailscience/plots/styles/styling_helpers.py
+++ b/openretailscience/plots/styles/styling_helpers.py
@@ -914,6 +914,8 @@ def _fit_outside_legend(ax: Axes, title: str | None) -> None:
     if ncols == 1:
         return
 
+    # Unlike the other callers, this one ignores the return: the same rect already reflowed
+    # successfully inside apply_chart_chrome earlier this call, so it cannot fail here.
     chrome_top, chrome_bottom = fig._ors_chrome_rect
     _reflow_axes(fig, top=chrome_top, bottom=chrome_bottom)
 

--- a/openretailscience/plots/styles/styling_helpers.py
+++ b/openretailscience/plots/styles/styling_helpers.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from matplotlib.artist import Artist
     from matplotlib.axes import Axes
     from matplotlib.backend_bases import RendererBase
+    from matplotlib.container import Container
     from matplotlib.figure import Figure
     from matplotlib.legend import Legend
     from matplotlib.text import Text
@@ -856,7 +857,7 @@ def apply_ticks(ax: Axes) -> None:
     _hide_zero_value_ticks(ax)
 
 
-def _build_outside_legend(ax: Axes, handles: list[Artist], labels: list[str], ncols: int) -> Legend:
+def _build_outside_legend(ax: Axes, handles: list[Artist | Container], labels: list[str], ncols: int) -> Legend:
     """Build the legend anchored outside the axes, spread over ``ncols`` columns."""
     style = PlotStyleHelper()
     return ax.legend(
@@ -901,21 +902,21 @@ def _fit_outside_legend(ax: Axes, title: str | None) -> None:
     handles = list(legend.legend_handles)
     labels = [text.get_text() for text in legend.get_texts()]
 
-    # Each candidate is measured rather than extrapolated from the single-column width: a column
-    # can cost more than the first one (its labels may be wider), so an estimate overshoots the cap.
+    # Every candidate is measured: a column can cost more width than the one before it (its
+    # labels may be wider), so a budget estimated from the first column's width overshoots the cap.
     ncols = 1
-    while legend.get_window_extent(renderer=renderer).height > axes_height and ncols < len(handles):
+    height = legend.get_window_extent(renderer=renderer).height
+    while height > axes_height and ncols < len(handles):
         candidate = _build_outside_legend(ax, handles, labels, ncols + 1)
         _style_legend(candidate, title)
-        if candidate.get_window_extent(renderer=renderer).width > width_cap:
+        candidate_box = candidate.get_window_extent(renderer=renderer)
+        if candidate_box.width > width_cap:
             _style_legend(_build_outside_legend(ax, handles, labels, ncols), title)
             break
-        ncols, legend = ncols + 1, candidate
+        ncols, height = ncols + 1, candidate_box.height
     if ncols == 1:
         return
 
-    # Unlike the other callers, this one ignores the return: the same rect already reflowed
-    # successfully inside apply_chart_chrome earlier this call, so it cannot fail here.
     chrome_top, chrome_bottom = fig._ors_chrome_rect
     _reflow_axes(fig, top=chrome_top, bottom=chrome_bottom)
 

--- a/tests/plots/styles/test_chart_chrome.py
+++ b/tests/plots/styles/test_chart_chrome.py
@@ -708,3 +708,76 @@ class TestApplyLegend:
             assert anchor.y0 == pytest.approx(0.0)
             assert anchor.x1 == pytest.approx(1.0)
             assert anchor.y1 == pytest.approx(1.0)
+
+
+class TestOutsideLegendFit:
+    """An outside legend is anchored to the axes top and grows downward.
+
+    More entries than the plot band can hold pushed the stack through the chrome's
+    source line and, once the overflow exceeded the bottom margin, off the figure.
+    """
+
+    SOURCE_LINE = "Traffic sensor data (Apr 2024 - Jun 2024), excludes days with sensor downtime over two hours"
+
+    @pytest.fixture
+    def store_footfall(self) -> pd.DataFrame:
+        """Monthly footfall for fourteen stores: more series than a 3.6in plot band holds."""
+        months = pd.date_range("2024-01-01", periods=12, freq="MS")
+        return pd.DataFrame(
+            {f"Store {store:02d}": [1000 + store * 50 + month * 10 for month in range(12)] for store in range(1, 15)},
+            index=months,
+        )
+
+    def _draw(self, df: pd.DataFrame, figsize: tuple[float, float]) -> tuple[plt.Figure, plt.Axes]:
+        """Render ``df`` as an outside-legend line chart at ``figsize`` and draw it once."""
+        fig, ax = plt.subplots(figsize=figsize)
+        line.plot(
+            df,
+            value_col=list(df.columns),
+            title="Footfall by store",
+            y_label="Visits",
+            source_text=self.SOURCE_LINE,
+            move_legend_outside=True,
+            ax=ax,
+        )
+        fig.canvas.draw()
+        return fig, ax
+
+    @staticmethod
+    def _source_box(fig: plt.Figure):
+        """Measure the source artist, found by prefix since chrome bakes its wrap in as newlines."""
+        artist = next(t for t in fig.texts if t.get_text().startswith("Traffic sensor data"))
+        return artist.get_window_extent(renderer=fig.canvas.get_renderer())
+
+    @staticmethod
+    def _column_count(ax: plt.Axes) -> int:
+        """Count the legend's rendered columns as the distinct x-positions of its entries."""
+        renderer = ax.get_figure().canvas.get_renderer()
+        return len({round(t.get_window_extent(renderer=renderer).x0) for t in ax.get_legend().get_texts()})
+
+    def test_tall_outside_legend_clears_the_source_line(self, store_footfall):
+        """The legend must not render on top of the source text."""
+        fig, ax = self._draw(store_footfall, (6.4, 3.6))
+        legend_box = ax.get_legend().get_window_extent(renderer=fig.canvas.get_renderer())
+
+        assert not legend_box.overlaps(self._source_box(fig))
+
+    def test_tall_outside_legend_keeps_every_entry_on_the_figure(self, store_footfall):
+        """Wrapping preserves all entries and keeps them inside the figure, not off the bottom."""
+        fig, ax = self._draw(store_footfall, (6.4, 3.6))
+        legend_box = ax.get_legend().get_window_extent(renderer=fig.canvas.get_renderer())
+
+        assert legend_box.y0 >= 0
+        assert len(ax.get_legend().get_texts()) == len(store_footfall.columns)
+
+    def test_short_outside_legend_keeps_one_column(self, store_footfall):
+        """A legend that already fits the plot band is left in a single column."""
+        _, ax = self._draw(store_footfall[["Store 01", "Store 02"]], (6.4, 3.6))
+
+        assert self._column_count(ax) == 1
+
+    def test_tall_outside_legend_wraps_into_columns(self, store_footfall):
+        """The fourteen-entry legend is what buys the vertical room: it wraps rather than overflowing."""
+        _, ax = self._draw(store_footfall, (6.4, 3.6))
+
+        assert self._column_count(ax) > 1

--- a/tests/plots/styles/test_chart_chrome.py
+++ b/tests/plots/styles/test_chart_chrome.py
@@ -134,6 +134,18 @@ def _topmost_axes_content_fig_y(*, labeltop: bool) -> float:
     return topmost_fig
 
 
+def _store_footfall(store_count: int) -> pd.DataFrame:
+    """Monthly footfall over a year for ``store_count`` stores, one labelled series each."""
+    months = pd.date_range("2024-01-01", periods=12, freq="MS")
+    return pd.DataFrame(
+        {
+            f"Store {store:02d}": [1000 + store * 50 + month * 10 for month in range(12)]
+            for store in range(1, store_count + 1)
+        },
+        index=months,
+    )
+
+
 class TestApplyChartChrome:
     """Verify the chrome layout engine renders only the present elements."""
 
@@ -720,19 +732,16 @@ class TestOutsideLegendFit:
     """
 
     SOURCE_LINE = "Traffic sensor data (Apr 2024 - Jun 2024), excludes days with sensor downtime over two hours"
+    FIGSIZE = (6.4, 3.6)
 
     @pytest.fixture
     def store_footfall(self) -> pd.DataFrame:
-        """Monthly footfall for fourteen stores: more series than a 3.6in plot band holds."""
-        months = pd.date_range("2024-01-01", periods=12, freq="MS")
-        return pd.DataFrame(
-            {f"Store {store:02d}": [1000 + store * 50 + month * 10 for month in range(12)] for store in range(1, 15)},
-            index=months,
-        )
+        """Fourteen stores: more series than the 3.6in plot band holds in one column."""
+        return _store_footfall(14)
 
-    def _draw(self, df: pd.DataFrame, figsize: tuple[float, float]) -> tuple[plt.Figure, plt.Axes]:
-        """Render ``df`` as an outside-legend line chart at ``figsize`` and draw it once."""
-        fig, ax = plt.subplots(figsize=figsize)
+    def _draw(self, df: pd.DataFrame, figsize: tuple[float, float] | None = None) -> tuple[plt.Figure, plt.Axes]:
+        """Render ``df`` as an outside-legend line chart and draw it once."""
+        fig, ax = plt.subplots(figsize=self.FIGSIZE if figsize is None else figsize)
         line.plot(
             df,
             value_col=list(df.columns),
@@ -745,11 +754,15 @@ class TestOutsideLegendFit:
         fig.canvas.draw()
         return fig, ax
 
-    @staticmethod
-    def _source_box(fig: plt.Figure) -> Bbox:
-        """Measure the source artist, matched by prefix since chrome bakes its wrap in as newlines."""
-        artist = next(t for t in fig.texts if t.get_text().startswith("Traffic sensor data"))
+    def _source_box(self, fig: plt.Figure) -> Bbox:
+        """Measure the source artist, un-baking the newlines chrome wraps into it."""
+        artist = next(t for t in fig.texts if t.get_text().replace("\n", " ") == self.SOURCE_LINE)
         return artist.get_window_extent(renderer=fig.canvas.get_renderer())
+
+    @staticmethod
+    def _legend_box(ax: plt.Axes) -> Bbox:
+        """Measure the axes' rendered legend."""
+        return ax.get_legend().get_window_extent(renderer=ax.get_figure().canvas.get_renderer())
 
     @staticmethod
     def _column_count(ax: plt.Axes) -> int:
@@ -759,44 +772,34 @@ class TestOutsideLegendFit:
 
     def test_tall_outside_legend_clears_the_source_line(self, store_footfall):
         """The legend must not render on top of the source text."""
-        fig, ax = self._draw(store_footfall, (6.4, 3.6))
-        legend_box = ax.get_legend().get_window_extent(renderer=fig.canvas.get_renderer())
+        fig, ax = self._draw(store_footfall)
 
-        assert not legend_box.overlaps(self._source_box(fig))
+        assert not self._legend_box(ax).overlaps(self._source_box(fig))
 
     def test_tall_outside_legend_keeps_every_entry_on_the_figure(self, store_footfall):
-        """Wrapping keeps every entry, and keeps them all on the canvas."""
-        fig, ax = self._draw(store_footfall, (6.4, 3.6))
-        legend_box = ax.get_legend().get_window_extent(renderer=fig.canvas.get_renderer())
+        """Wrapping keeps every entry, and keeps them all on the canvas.
+
+        The right-edge bound is what pins the reflow that follows the wrap: widening the legend
+        without re-reserving its slot pushes a whole column past the figure, where it is clipped.
+        """
+        fig, ax = self._draw(store_footfall)
+        legend_box = self._legend_box(ax)
 
         assert legend_box.y0 >= 0
+        assert legend_box.x1 <= fig.bbox.width
         assert len(ax.get_legend().get_texts()) == len(store_footfall.columns)
 
-    def test_short_outside_legend_keeps_one_column(self, store_footfall):
-        """A legend that already fits the plot band is left in a single column."""
-        _, ax = self._draw(store_footfall[["Store 01", "Store 02"]], (6.4, 3.6))
+    @pytest.mark.parametrize(
+        ("store_count", "figsize", "expected_columns"),
+        [(2, (6.4, 3.6), 1), (14, (6.4, 3.6), 2), (24, (7.0, 3.2), 2)],
+    )
+    def test_outside_legend_wraps_into_columns_within_the_width_cap(self, store_count, figsize, expected_columns):
+        """A legend that fits the plot band stays single-column; a taller one wraps, but only up to the cap.
 
-        assert self._column_count(ax) == 1
-
-    def test_tall_outside_legend_wraps_into_columns(self, store_footfall):
-        """A legend taller than the plot band buys its vertical room by wrapping into columns."""
-        _, ax = self._draw(store_footfall, (6.4, 3.6))
-
-        assert self._column_count(ax) > 1
-
-    def test_wrapped_legend_never_outgrows_the_width_cap(self):
-        """Columns stop before the legend claims more than its share, leaving the axes the rest.
-
-        Twenty-four entries at this size are the case that overshot when the column budget was
-        extrapolated from the single-column width instead of measuring each candidate.
+        The twenty-four-entry row is held to two columns by the cap: its third column is wider
+        than the first, so the legend would claim over half the figure.
         """
-        months = pd.date_range("2024-01-01", periods=12, freq="MS")
-        many_stores = pd.DataFrame(
-            {f"Store {store:02d}": [1000 + store * 50 + month * 10 for month in range(12)] for store in range(1, 25)},
-            index=months,
-        )
-        fig, ax = self._draw(many_stores, (7.0, 3.2))
-        legend_box = ax.get_legend().get_window_extent(renderer=fig.canvas.get_renderer())
+        fig, ax = self._draw(_store_footfall(store_count), figsize)
 
-        assert self._column_count(ax) > 1
-        assert legend_box.width / fig.bbox.width <= _MAX_OUTSIDE_LEGEND_WIDTH_FRAC
+        assert self._column_count(ax) == expected_columns
+        assert self._legend_box(ax).width / fig.bbox.width <= _MAX_OUTSIDE_LEGEND_WIDTH_FRAC

--- a/tests/plots/styles/test_chart_chrome.py
+++ b/tests/plots/styles/test_chart_chrome.py
@@ -13,6 +13,7 @@ from openretailscience.options import PlotStyleHelper, get_option, option_contex
 from openretailscience.plots import heatmap, line
 from openretailscience.plots.styles.styling_helpers import (
     _CHROME_TAB_WIDTH_IN,
+    _MAX_OUTSIDE_LEGEND_WIDTH_FRAC,
     _CHROME_TOP_LABEL_HEADROOM_FACTOR,
     apply_chart_chrome,
     apply_legend,
@@ -782,3 +783,20 @@ class TestOutsideLegendFit:
         _, ax = self._draw(store_footfall, (6.4, 3.6))
 
         assert self._column_count(ax) > 1
+
+    def test_wrapped_legend_never_outgrows_the_width_cap(self):
+        """Columns stop before the legend claims more than its share, leaving the axes the rest.
+
+        Twenty-four entries at this size are the case that overshot when the column budget was
+        extrapolated from the single-column width instead of measuring each candidate.
+        """
+        months = pd.date_range("2024-01-01", periods=12, freq="MS")
+        many_stores = pd.DataFrame(
+            {f"Store {store:02d}": [1000 + store * 50 + month * 10 for month in range(12)] for store in range(1, 25)},
+            index=months,
+        )
+        fig, ax = self._draw(many_stores, (7.0, 3.2))
+        legend_box = ax.get_legend().get_window_extent(renderer=fig.canvas.get_renderer())
+
+        assert self._column_count(ax) > 1
+        assert legend_box.width / fig.bbox.width <= _MAX_OUTSIDE_LEGEND_WIDTH_FRAC

--- a/tests/plots/styles/test_chart_chrome.py
+++ b/tests/plots/styles/test_chart_chrome.py
@@ -13,8 +13,8 @@ from openretailscience.options import PlotStyleHelper, get_option, option_contex
 from openretailscience.plots import heatmap, line
 from openretailscience.plots.styles.styling_helpers import (
     _CHROME_TAB_WIDTH_IN,
-    _MAX_OUTSIDE_LEGEND_WIDTH_FRAC,
     _CHROME_TOP_LABEL_HEADROOM_FACTOR,
+    _MAX_OUTSIDE_LEGEND_WIDTH_FRAC,
     apply_chart_chrome,
     apply_legend,
     standard_graph_styles,

--- a/tests/plots/styles/test_chart_chrome.py
+++ b/tests/plots/styles/test_chart_chrome.py
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import pytest
 from matplotlib.colors import to_hex
+from matplotlib.transforms import Bbox
 
 from openretailscience.options import PlotStyleHelper, get_option, option_context
 from openretailscience.plots import heatmap, line
@@ -711,10 +712,10 @@ class TestApplyLegend:
 
 
 class TestOutsideLegendFit:
-    """An outside legend is anchored to the axes top and grows downward.
+    """An outside legend stays beside the plot however many entries it carries.
 
-    More entries than the plot band can hold pushed the stack through the chrome's
-    source line and, once the overflow exceeded the bottom margin, off the figure.
+    It is anchored to the axes top and grows downward, so without a column wrap it
+    runs through the chrome's source line and off the bottom of the figure.
     """
 
     SOURCE_LINE = "Traffic sensor data (Apr 2024 - Jun 2024), excludes days with sensor downtime over two hours"
@@ -744,8 +745,8 @@ class TestOutsideLegendFit:
         return fig, ax
 
     @staticmethod
-    def _source_box(fig: plt.Figure):
-        """Measure the source artist, found by prefix since chrome bakes its wrap in as newlines."""
+    def _source_box(fig: plt.Figure) -> Bbox:
+        """Measure the source artist, matched by prefix since chrome bakes its wrap in as newlines."""
         artist = next(t for t in fig.texts if t.get_text().startswith("Traffic sensor data"))
         return artist.get_window_extent(renderer=fig.canvas.get_renderer())
 
@@ -763,7 +764,7 @@ class TestOutsideLegendFit:
         assert not legend_box.overlaps(self._source_box(fig))
 
     def test_tall_outside_legend_keeps_every_entry_on_the_figure(self, store_footfall):
-        """Wrapping preserves all entries and keeps them inside the figure, not off the bottom."""
+        """Wrapping keeps every entry, and keeps them all on the canvas."""
         fig, ax = self._draw(store_footfall, (6.4, 3.6))
         legend_box = ax.get_legend().get_window_extent(renderer=fig.canvas.get_renderer())
 
@@ -777,7 +778,7 @@ class TestOutsideLegendFit:
         assert self._column_count(ax) == 1
 
     def test_tall_outside_legend_wraps_into_columns(self, store_footfall):
-        """The fourteen-entry legend is what buys the vertical room: it wraps rather than overflowing."""
+        """A legend taller than the plot band buys its vertical room by wrapping into columns."""
         _, ax = self._draw(store_footfall, (6.4, 3.6))
 
         assert self._column_count(ax) > 1


### PR DESCRIPTION
> ## ⚠️ Draft — regresses `main` at untested figure sizes
>
> The fix below works at the size the tests cover (14 series, 6.4×3.6in) and is worse than `main` elsewhere. Measured against a no-op stand-in for `main`:
>
> | case | axes height (main → branch) | legend off right edge (main → branch) |
> |---|---|---|
> | 40 series, 6.4×3.6 | 277.2 → **38.8px** | 60.4 → 0.0 |
> | 24 series, 7.0×3.2 | 246.4 → **144.8px** | 55.3 → 0.0 |
> | 18 series, 5.0×2.6 | 9.1 → 9.1 | 0.0 → **110.8px** |
> | 14 series, 6.4×3.6 *(tested)* | 167.1 → 171.0 | 0.0 → 0.0 |
>
> Two regressions, in tension with each other: the trailing `_reflow_axes` collapses the data area when the wrapped legend still doesn't fit, and skipping it instead leaves the widened legend hanging off the right edge (`tight_layout` warns rather than raising, so the reflow returns `True` on a no-op). Guarding the reflow fixes the first and worsens the second everywhere.
>
> Blocked on a decision about what an unfittable legend should do. Details in [this comment](https://github.com/Data-Simply/openretailscience/pull/561#issuecomment-5353969101). Green CI and 100% patch coverage below are real but only exercise the one working size.

## Problem

With `move_legend_outside=True`, a legend with more entries than the plot band can hold renders on top of `source_text`, and once the overflow exceeds the bottom margin, entries run off the figure entirely.

Reproduced with `bar.plot` at 6.4×4.0in with 12 series: legend `y0 = 0.044` vs. source `y1 = 0.090` in figure fractions (`Bbox.overlaps() == True`). At 6.4×3.5in the legend reaches `y0 = -0.096` — the last entries are outside the canvas. Not bar-specific; `line.plot` does the same (14 series at 6.4×3.6in → `y0 = -0.116`).

## Cause

Three things in `styling_helpers.py` combine:

1. `apply_legend` anchors the outside legend at `bbox_to_anchor=[1.02, 1.0]`, `loc="upper left"` — pinned to the axes **top**, growing downward with nothing bounding its height.
2. `apply_chart_chrome` reserves a bottom band for `source_text` and reflows only the **axes box** into the remaining rect via `fig.tight_layout(pad=0, rect=...)`. That narrows the axes for the legend's *width*, never its *height*.
3. `_ChromeLayoutEngine.execute` re-places chrome each draw from stored inch gaps, likewise never consulting the legend bbox.

So once the legend is taller than the axes, it spills straight through the source band.

## Attempted fix

`_fit_outside_legend`, run from `standard_graph_styles` after chrome has settled the axes box and before auto-rotation. It builds a candidate legend at each column count and measures it, accepting the candidate only if it stays within `_MAX_OUTSIDE_LEGEND_WIDTH_FRAC` of the figure width, until the stack fits the plot height. It then repeats the chrome reflow so `tight_layout` reserves the widened slot — which is the step that misbehaves at other sizes, per the note above.

Also factored the shared legend construction and font application out of `apply_legend` into `_build_outside_legend` / `_style_legend`, since the wrapped rebuild needs both. That extraction is independent of the layout problem.

## Tests

`TestOutsideLegendFit` in `tests/plots/styles/test_chart_chrome.py`: the legend clears the source line, every entry stays on the figure, tall legends wrap into columns, a legend that already fits keeps one column, and a wrapped legend never outgrows the width cap.

Each was confirmed red before the code it guards. **They all pin the same figure size**, which is why the regressions above went undetected — extending them across sizes is part of whatever redesign follows.

Full suite: 1412 passed.

## Known problems beyond the two regressions

- The column count is frozen at build time, so `fig.set_size_inches` leaves it stale — unlike the rest of the chrome pipeline, which re-derives on every draw.
- `axes_height` is sampled before `_auto_rotate_categorical_x_ticks`, which then changes that height in either direction.
- The width cap bounds only the *added* columns, never the single-column baseline, so two long-labelled series can take 78% of the figure width unchecked.
- Candidates are rebuilt from `legend.legend_handles` (matplotlib's proxies), so composite handles such as `ErrorbarContainer` degrade to a bare `Line2D`.

## Out of scope

- `x_label` overlaps `source_text` at short figure heights (≤3.0in for a 5-series bar).
- The y-label is clipped off the left edge at the default 6.4×4.8in with chrome on — `_CHROME_LEFT_AXES_MARGIN = 0.015` leaves no room once chrome anchors the axes to the spine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXQ2M34gfBZqnZeoCniybR)_
