### PR TITLE
Add CLVStats.sample() for fitting on customer subsets

### DIFF
--- a/docs/experimental/clv.md
+++ b/docs/experimental/clv.md
@@ -112,9 +112,9 @@ gamma_gamma.fit()
 
 ## Fitting on a sample, scoring everyone
 
-Pareto/NBD sampling is expensive on a large customer base, so a common workflow is to fit on a
-subset and predict on everyone. `clv.sample()` returns **another `CLVStats`** over a random subset
-of customers, so the sample keeps `.df`, `.repeat_buyers`, `.covariate_cols`, and `.pymc_time_unit`:
+Fitting a Pareto/NBD on a large customer base is expensive, so a common workflow is to fit on a
+subset and predict on everyone. `clv.sample()` returns **another `CLVStats`** over a random subset of
+customers, so the sample keeps `.df`, `.repeat_buyers`, `.covariate_cols`, and `.pymc_time_unit`:
 
 ```python
 clv = CLVStats(transactions, period="week")
@@ -130,19 +130,17 @@ expected_purchases = pareto.expected_purchases(data=clv.df, future_t=52)
 ```
 
 `n` draws an exact number of customers, and yields every customer if it exceeds the population
-rather than raising. `frac` is a share in `(0, 1]` drawn independently per customer, so the row
-count lands *near* `frac` x population rather than exactly on it; it costs a single pushed-down
-predicate instead of `n`'s sort.
+rather than raising. `frac` is a share in `(0, 1]` drawn independently per customer, so the row count
+lands *near* `frac` x population rather than exactly on it; it costs a single pushed-down predicate
+instead of `n`'s sort.
 
-Selection is a deterministic hash of `customer_id` salted with `random_state` (default `42`), not a
-`random()` predicate, so the same arguments draw the same customers on every execution and on every
-re-execution of `.table` — a re-rolled sample would silently change which customers a model was
-fitted on. A different `random_state` draws an independent sample.
+Customers are selected by a deterministic hash of `customer_id` salted with `random_state` (default
+`42`), so the same arguments draw the same customers on every execution, and a different
+`random_state` draws an independent sample.
 
-Sampling the summary is equivalent to sampling customers before aggregating, since a customer's
-summary row depends only on their own transactions. One aggregate pass therefore serves both the fit
-and the scoring, and a sampled row is exactly the row that customer has in the full `.df`. Row order
-in the result is not meaningful.
+Sampling the summary is equivalent to sampling customers before aggregating, since a customer's row
+depends only on their own transactions: one aggregate pass serves both the fit and the scoring, and a
+sampled row is exactly that customer's row in the full `.df`. Row order is not meaningful.
 
 ## Extra columns and covariates
 

--- a/docs/experimental/clv.md
+++ b/docs/experimental/clv.md
@@ -79,17 +79,26 @@ print(clv.df.sort_values("customer_id").reset_index(drop=True))
 # 2          103          1      2.0  2.714286            80.0
 ```
 
-The summary feeds pymc-marketing directly (install it separately):
+The summary feeds pymc-marketing directly (install it separately). Fitting a Pareto/NBD on a large
+customer base is expensive, so the usual shape is to fit on a sample of customers and score all of
+them: `clv.sample()` returns **another `CLVStats`**, so the sample keeps `.df`, `.repeat_buyers`,
+`.covariate_cols`, and `.pymc_time_unit`.
 
 ```python
 from pymc_marketing.clv import ParetoNBDModel, GammaGammaModel
 
 clv = CLVStats(transactions, period="week", observation_period_end="2023-01-29")
-pareto = ParetoNBDModel(data=clv.df) # frequency, recency, T
+# Drop this line and fit on clv.df / clv.repeat_buyers when the whole base is tractable.
+train = clv.sample(n=50_000) # or frac=0.1 -- exactly one of the two
+
+pareto = ParetoNBDModel(data=train.df) # frequency, recency, T
 pareto.fit()
 
-gamma_gamma = GammaGammaModel(data=clv.repeat_buyers) # frequency > 0
+gamma_gamma = GammaGammaModel(data=train.repeat_buyers) # frequency > 0
 gamma_gamma.fit()
+
+# Score every customer from the models fitted on the sample.
+expected_purchases = pareto.expected_purchases(data=clv.df, future_t=52)
 ```
 
 <!-- markdownlint-disable MD046 -->
@@ -110,24 +119,7 @@ gamma_gamma.fit()
     computes it with no month conversion and no `time_unit`.
 <!-- markdownlint-enable MD046 -->
 
-## Fitting on a sample, scoring everyone
-
-Fitting a Pareto/NBD on a large customer base is expensive, so a common workflow is to fit on a
-subset and predict on everyone. `clv.sample()` returns **another `CLVStats`** over a random subset of
-customers, so the sample keeps `.df`, `.repeat_buyers`, `.covariate_cols`, and `.pymc_time_unit`:
-
-```python
-clv = CLVStats(transactions, period="week")
-train = clv.sample(n=50_000)  # or frac=0.1 -- exactly one of the two
-
-pareto = ParetoNBDModel(data=train.df)
-pareto.fit()
-gamma_gamma = GammaGammaModel(data=train.repeat_buyers)
-gamma_gamma.fit()
-
-# Score the full population from the model fitted on the sample.
-expected_purchases = pareto.expected_purchases(data=clv.df, future_t=52)
-```
+## Sampling customers
 
 `n` draws an exact number of customers, and yields every customer if it exceeds the population
 rather than raising. `frac` is a share in `(0, 1]` drawn independently per customer, so the row count

--- a/docs/experimental/clv.md
+++ b/docs/experimental/clv.md
@@ -110,6 +110,40 @@ gamma_gamma.fit()
     computes it with no month conversion and no `time_unit`.
 <!-- markdownlint-enable MD046 -->
 
+## Fitting on a sample, scoring everyone
+
+Pareto/NBD sampling is expensive on a large customer base, so a common workflow is to fit on a
+subset and predict on everyone. `clv.sample()` returns **another `CLVStats`** over a random subset
+of customers, so the sample keeps `.df`, `.repeat_buyers`, `.covariate_cols`, and `.pymc_time_unit`:
+
+```python
+clv = CLVStats(transactions, period="week")
+train = clv.sample(n=50_000)  # or frac=0.1 -- exactly one of the two
+
+pareto = ParetoNBDModel(data=train.df)
+pareto.fit()
+gamma_gamma = GammaGammaModel(data=train.repeat_buyers)
+gamma_gamma.fit()
+
+# Score the full population from the model fitted on the sample.
+expected_purchases = pareto.expected_purchases(data=clv.df, future_t=52)
+```
+
+`n` draws an exact number of customers, and yields every customer if it exceeds the population
+rather than raising. `frac` is a share in `(0, 1]` drawn independently per customer, so the row
+count lands *near* `frac` x population rather than exactly on it; it costs a single pushed-down
+predicate instead of `n`'s sort.
+
+Selection is a deterministic hash of `customer_id` salted with `random_state` (default `42`), not a
+`random()` predicate, so the same arguments draw the same customers on every execution and on every
+re-execution of `.table` — a re-rolled sample would silently change which customers a model was
+fitted on. A different `random_state` draws an independent sample.
+
+Sampling the summary is equivalent to sampling customers before aggregating, since a customer's
+summary row depends only on their own transactions. One aggregate pass therefore serves both the fit
+and the scoring, and a sampled row is exactly the row that customer has in the full `.df`. Row order
+in the result is not meaningful.
+
 ## Extra columns and covariates
 
 `customer_attributes` attaches a caller-supplied per-customer table (one row per `customer_id`) to the

--- a/docs/experimental/clv.md
+++ b/docs/experimental/clv.md
@@ -81,13 +81,14 @@ print(clv.df.sort_values("customer_id").reset_index(drop=True))
 
 The summary feeds pymc-marketing directly (install it separately). Fitting a Pareto/NBD on a large
 customer base is expensive, so the usual shape is to fit on a sample of customers and score all of
-them: `clv.sample()` returns **another `CLVStats`**, so the sample keeps `.df`, `.repeat_buyers`,
+them: `clv.sample(n=...)` returns **another `CLVStats`**, so the sample keeps `.df`, `.repeat_buyers`,
 `.covariate_cols`, and `.pymc_time_unit`.
 
 ```python
 from pymc_marketing.clv import ParetoNBDModel, GammaGammaModel
 
 clv = CLVStats(transactions, period="week", observation_period_end="2023-01-29")
+# Shape only -- on the three-customer frame above, n=50_000 exceeds the population and train is clv.
 # Drop this line and fit on clv.df / clv.repeat_buyers when the whole base is tractable.
 train = clv.sample(n=50_000) # or frac=0.1 -- exactly one of the two
 
@@ -122,17 +123,24 @@ expected_purchases = pareto.expected_purchases(data=clv.df, future_t=52)
 ## Sampling customers
 
 `n` draws an exact number of customers, and yields every customer if it exceeds the population
-rather than raising. `frac` is a share in `(0, 1]` drawn independently per customer, so the row count
-lands *near* `frac` x population rather than exactly on it; it costs a single pushed-down predicate
-instead of `n`'s sort.
+rather than raising. `frac` is a share in `(0, 1]` decided per customer, so the row count lands
+*near* `frac` x population rather than exactly on it; it costs a single predicate instead of `n`'s
+sort, and is rejected below the hash's `1e-6` bucket resolution.
 
 Customers are selected by a deterministic hash of `customer_id` salted with `random_state` (default
-`42`), so the same arguments draw the same customers on every execution, and a different
-`random_state` draws an independent sample.
+`42`). The hash is the backend's own: a draw repeats for one engine at one version (DuckDB's `HASH`
+changes between releases), so record the drawn ids, not the seed, when a fit must be reproduced.
+Backends with no Ibis `hash` rule (SQLite, MySQL, Trino, Athena) raise when the sample is executed.
 
-Sampling the summary is equivalent to sampling customers before aggregating, since a customer's row
-depends only on their own transactions: one aggregate pass serves both the fit and the scoring, and a
-sampled row is exactly that customer's row in the full `.df`. Row order is not meaningful.
+Draws nest rather than partition: at one `random_state`, `sample(frac=0.2)` is a subset of
+`sample(frac=0.8)` and re-sampling a sample returns it unchanged; a different `random_state` re-draws
+independently, which still overlaps. Neither gives a disjoint train/holdout split.
+
+A sampled row is exactly that customer's row in the full `.df`, so the fit and the scoring agree.
+Filtering transactions before constructing `CLVStats` is *not* the same thing — `T` is measured from
+`observation_period_end`, which defaults to the population's latest transaction, and one-hot
+reference levels come from the population's categories. Sampling makes the fit tractable, not the
+query: `clv.df` and `train.df` each run the full aggregation. Row order is not meaningful.
 
 ## Extra columns and covariates
 

--- a/openretailscience/.agents/skills/using-openretailscience/references/clv.md
+++ b/openretailscience/.agents/skills/using-openretailscience/references/clv.md
@@ -15,7 +15,8 @@ clv = CLVStats(data, period="week", observation_period_end=None)
 Reads `customer_id`, `transaction_date` (must be a date/datetime type), and `unit_spend`
 from the options system. Undated rows and returns-only days (net spend zero or less) are dropped
 (a customer left with none drops out). Read `.table` (Ibis) / `.df` (pandas); `.repeat_buyers` is the
-GammaGamma-ready subset (`frequency > 0`); `.covariate_cols`
+GammaGamma-ready subset (`frequency > 0`); `.sample()` draws a customer subset to fit on;
+`.covariate_cols`
 lists the attached customer_attributes / one-hot columns; `.pymc_time_unit` is the matching
  pymc-marketing `time_unit`. `help(CLVStats)` for full Args/Raises.
 
@@ -85,6 +86,37 @@ ParetoNBDModel(data=clv.df, model_config={
 Values are used verbatim in column names (same as ibis `pivot_wider`, no sanitisation).
 `GammaGammaModel` has **no** covariate support in pymc-marketing, so for spend-by-channel, fit a
 separate Gamma-Gamma per channel.
+
+## Fitting on a sample, scoring everyone
+
+`.sample()` returns **another `CLVStats`** over a random subset of customers, so the sample keeps
+`.df`, `.repeat_buyers`, `.covariate_cols`, and `.pymc_time_unit`. Fit on the sample when the full
+population is too large for MCMC; predict on the full `.df`.
+
+```python
+clv = CLVStats(data, period="week")
+train = clv.sample(n=50_000)  # or frac=0.1; exactly one of the two
+
+pareto = ParetoNBDModel(data=train.df)
+pareto.fit()
+gamma_gamma = GammaGammaModel(data=train.repeat_buyers)
+gamma_gamma.fit()
+
+everyone = pareto.expected_purchases(data=clv.df, future_t=52)  # score the full population
+```
+
+- `n` — exact number of customers; yields every customer if it exceeds the population (no error).
+  Costs a backend top-N sort.
+- `frac` — share in `(0, 1]`, drawn per customer, so the count lands *near* `frac` * population, not
+  on it. One pushed-down predicate, no sort.
+- `random_state` — defaults to `42`. Selection is a deterministic hash of `customer_id` salted with it,
+  so the same arguments draw the same customers on every execution and on re-execution of `.table`;
+  a different `random_state` draws an independent sample.
+
+Sampling the summary is equivalent to sampling customers before aggregating (a customer's row depends
+only on their own transactions), so one aggregate pass serves both the fit and the scoring, and a
+sampled row is byte-for-byte the row that customer has in the full `.df`. Row order in the result is
+not meaningful.
 
 ## Feeding pymc-marketing
 

--- a/openretailscience/.agents/skills/using-openretailscience/references/clv.md
+++ b/openretailscience/.agents/skills/using-openretailscience/references/clv.md
@@ -109,14 +109,13 @@ everyone = pareto.expected_purchases(data=clv.df, future_t=52)  # score the full
   Costs a backend top-N sort.
 - `frac` — share in `(0, 1]`, drawn per customer, so the count lands *near* `frac` * population, not
   on it. One pushed-down predicate, no sort.
-- `random_state` — defaults to `42`. Selection is a deterministic hash of `customer_id` salted with it,
-  so the same arguments draw the same customers on every execution and on re-execution of `.table`;
-  a different `random_state` draws an independent sample.
+- `random_state` — defaults to `42`. Customers are selected by a deterministic hash of `customer_id`
+  salted with it, so the same arguments always draw the same customers and a different `random_state`
+  draws an independent sample.
 
 Sampling the summary is equivalent to sampling customers before aggregating (a customer's row depends
 only on their own transactions), so one aggregate pass serves both the fit and the scoring, and a
-sampled row is byte-for-byte the row that customer has in the full `.df`. Row order in the result is
-not meaningful.
+sampled row is the row that customer has in the full `.df`. Row order is not meaningful.
 
 ## Feeding pymc-marketing
 

--- a/openretailscience/.agents/skills/using-openretailscience/references/clv.md
+++ b/openretailscience/.agents/skills/using-openretailscience/references/clv.md
@@ -15,10 +15,9 @@ clv = CLVStats(data, period="week", observation_period_end=None)
 Reads `customer_id`, `transaction_date` (must be a date/datetime type), and `unit_spend`
 from the options system. Undated rows and returns-only days (net spend zero or less) are dropped
 (a customer left with none drops out). Read `.table` (Ibis) / `.df` (pandas); `.repeat_buyers` is the
-GammaGamma-ready subset (`frequency > 0`); `.sample()` draws a customer subset to fit on;
-`.covariate_cols`
-lists the attached customer_attributes / one-hot columns; `.pymc_time_unit` is the matching
- pymc-marketing `time_unit`. `help(CLVStats)` for full Args/Raises.
+GammaGamma-ready subset (`frequency > 0`); `.sample(n=...)` draws a customer subset to fit on;
+`.covariate_cols` lists the attached customer_attributes / one-hot columns; `.pymc_time_unit` is the
+matching pymc-marketing `time_unit`. `help(CLVStats)` for full Args/Raises.
 
 ## Output columns
 
@@ -89,7 +88,7 @@ separate Gamma-Gamma per channel.
 
 ## Feeding pymc-marketing
 
-Fit on a sample of customers, score all of them. `.sample()` returns **another `CLVStats`**, so the
+Fit on a sample of customers, score all of them. `.sample(n=...)` returns **another `CLVStats`**, so the
 sample keeps `.df`, `.repeat_buyers`, `.covariate_cols`, and `.pymc_time_unit`.
 
 ```python
@@ -129,15 +128,28 @@ computes it with no month conversion and no `time_unit`.
 
 - `n` — exact number of customers; yields every customer if it exceeds the population (no error).
   Costs a backend top-N sort.
-- `frac` — share in `(0, 1]`, drawn per customer, so the count lands *near* `frac` * population, not
-  on it. One pushed-down predicate, no sort.
+- `frac` — share in `(0, 1]`, decided per customer, so the count lands *near* `frac` * population, not
+  on it. One predicate, no sort; **raises** below the hash's `1e-6` bucket resolution.
 - `random_state` — defaults to `42`. Customers are selected by a deterministic hash of `customer_id`
-  salted with it, so the same arguments always draw the same customers and a different `random_state`
-  draws an independent sample.
+  salted with it.
 
-Sampling the summary is equivalent to sampling customers before aggregating (a customer's row depends
-only on their own transactions), so one aggregate pass serves both the fit and the scoring, and a
-sampled row is the row that customer has in the full `.df`. Row order is not meaningful.
+**Reproducibility is per engine and per version.** The key compiles to the backend's own hash, and
+DuckDB's `HASH` output changes between releases, so record the drawn ids rather than the seed when a
+fit must be reproduced. Backends with no Ibis `hash` rule (SQLite, MySQL, Trino, Athena) raise when
+the sample is executed, not when `sample()` is called.
+
+**Draws nest, they do not partition.** At one `random_state`, `sample(frac=0.2)` is a subset of
+`sample(frac=0.8)` and re-sampling a sample returns it unchanged; a different `random_state` re-draws
+independently, which still overlaps. There is no disjoint train/holdout split.
+
+A sample's `.df` validates NULL covariates over **its own rows only**, so `train.df` can pass where
+`clv.df` raises. Read `clv.df` before the fit if the covariates are not known complete.
+
+A sampled row is the row that customer has in the full `.df`, so the fit and the scoring agree. This
+is **not** the same as filtering transactions before constructing `CLVStats`: `T` is measured from
+`observation_period_end`, which defaults to the population's latest transaction, and one-hot
+reference levels come from the population's categories. Sampling makes the fit tractable, not the
+query — `clv.df` and `train.df` each run the full aggregation. Row order is not meaningful.
 
 ## Caveat: truncated history
 

--- a/openretailscience/.agents/skills/using-openretailscience/references/clv.md
+++ b/openretailscience/.agents/skills/using-openretailscience/references/clv.md
@@ -87,49 +87,26 @@ Values are used verbatim in column names (same as ibis `pivot_wider`, no sanitis
 `GammaGammaModel` has **no** covariate support in pymc-marketing, so for spend-by-channel, fit a
 separate Gamma-Gamma per channel.
 
-## Fitting on a sample, scoring everyone
-
-`.sample()` returns **another `CLVStats`** over a random subset of customers, so the sample keeps
-`.df`, `.repeat_buyers`, `.covariate_cols`, and `.pymc_time_unit`. Fit on the sample when the full
-population is too large for MCMC; predict on the full `.df`.
-
-```python
-clv = CLVStats(data, period="week")
-train = clv.sample(n=50_000)  # or frac=0.1; exactly one of the two
-
-pareto = ParetoNBDModel(data=train.df)
-pareto.fit()
-gamma_gamma = GammaGammaModel(data=train.repeat_buyers)
-gamma_gamma.fit()
-
-everyone = pareto.expected_purchases(data=clv.df, future_t=52)  # score the full population
-```
-
-- `n` — exact number of customers; yields every customer if it exceeds the population (no error).
-  Costs a backend top-N sort.
-- `frac` — share in `(0, 1]`, drawn per customer, so the count lands *near* `frac` * population, not
-  on it. One pushed-down predicate, no sort.
-- `random_state` — defaults to `42`. Customers are selected by a deterministic hash of `customer_id`
-  salted with it, so the same arguments always draw the same customers and a different `random_state`
-  draws an independent sample.
-
-Sampling the summary is equivalent to sampling customers before aggregating (a customer's row depends
-only on their own transactions), so one aggregate pass serves both the fit and the scoring, and a
-sampled row is the row that customer has in the full `.df`. Row order is not meaningful.
-
 ## Feeding pymc-marketing
+
+Fit on a sample of customers, score all of them. `.sample()` returns **another `CLVStats`**, so the
+sample keeps `.df`, `.repeat_buyers`, `.covariate_cols`, and `.pymc_time_unit`.
 
 ```python
 from openretailscience.experimental.clv import CLVStats
 from pymc_marketing.clv import ParetoNBDModel, GammaGammaModel
 
 clv = CLVStats(data)
+# Drop this line and fit on clv.df / clv.repeat_buyers when the full population is tractable.
+train = clv.sample(n=50_000) # or frac=0.1; exactly one of the two
 
-pareto = ParetoNBDModel(data=clv.df) # frequency, recency, T
+pareto = ParetoNBDModel(data=train.df) # frequency, recency, T
 pareto.fit()
 
-gamma_gamma = GammaGammaModel(data=clv.repeat_buyers) # frequency > 0
+gamma_gamma = GammaGammaModel(data=train.repeat_buyers) # frequency > 0
 gamma_gamma.fit()
+
+everyone = pareto.expected_purchases(data=clv.df, future_t=52) # score the full population
 ```
 
 **Finite-horizon CLV: pass `time_unit`, or it fails silently.**
@@ -147,6 +124,20 @@ Want an undiscounted CLV over a fixed horizon set directly in the model's units 
 next 52 weeks)?
 `pareto.expected_purchases(data=clv.df, future_t=52) * gamma_gamma.expected_customer_spend(data=clv.repeat_buyers)`
 computes it with no month conversion and no `time_unit`.
+
+### sample() arguments
+
+- `n` — exact number of customers; yields every customer if it exceeds the population (no error).
+  Costs a backend top-N sort.
+- `frac` — share in `(0, 1]`, drawn per customer, so the count lands *near* `frac` * population, not
+  on it. One pushed-down predicate, no sort.
+- `random_state` — defaults to `42`. Customers are selected by a deterministic hash of `customer_id`
+  salted with it, so the same arguments always draw the same customers and a different `random_state`
+  draws an independent sample.
+
+Sampling the summary is equivalent to sampling customers before aggregating (a customer's row depends
+only on their own transactions), so one aggregate pass serves both the fit and the scoring, and a
+sampled row is the row that customer has in the full `.df`. Row order is not meaningful.
 
 ## Caveat: truncated history
 

--- a/openretailscience/.agents/skills/using-openretailscience/scripts/example_clv_stats.py
+++ b/openretailscience/.agents/skills/using-openretailscience/scripts/example_clv_stats.py
@@ -13,9 +13,9 @@ from openretailscience.experimental.clv import CLVStats
 rng = np.random.default_rng(42)
 
 # ~600 customers shopping across 2023. Each starts on a random day in the first ~200 days
-# and makes 1-11 purchases; one-time buyers arise naturally and get frequency 0. Enough customers
-# that the sampling noise in the frequency/monetary correlation stays well inside repeat_buyers'
-# independence check, for the full summary and for the sample drawn below alike.
+# and makes 1-11 purchases; one-time buyers arise naturally and get frequency 0. 600 rather than
+# fewer: the frequency/monetary correlation must stay inside repeat_buyers' independence check for
+# the sample drawn below too.
 n_customers = 600
 epoch = np.datetime64("2023-01-01")
 last_day_offset = 364  # 2023-12-31
@@ -56,9 +56,8 @@ summary_asof = CLVStats(transactions, period="week", observation_period_end="202
 # repeat_buyers (frequency > 0) is the GammaGammaModel input.
 repeat_buyers = clv.repeat_buyers
 
-# sample() draws a random customer subset as another CLVStats, for fitting a model on a tractable
-# population and scoring everyone from clv.df. Pass n (exact count) or frac (share), never both;
-# selection is a deterministic hash of customer_id salted with random_state (default 42).
+# sample() draws a random customer subset as another CLVStats: fit on it, score everyone from clv.df.
+# Pass n (exact count) or frac (share), never both; the draw is deterministic given random_state.
 train = clv.sample(n=150)
 train_repeat_buyers = train.repeat_buyers  # the sample's GammaGammaModel input
 

--- a/openretailscience/.agents/skills/using-openretailscience/scripts/example_clv_stats.py
+++ b/openretailscience/.agents/skills/using-openretailscience/scripts/example_clv_stats.py
@@ -13,9 +13,9 @@ from openretailscience.experimental.clv import CLVStats
 rng = np.random.default_rng(42)
 
 # ~600 customers shopping across 2023. Each starts on a random day in the first ~200 days
-# and makes 1-11 purchases; one-time buyers arise naturally and get frequency 0. 600 rather than
-# fewer: the frequency/monetary correlation must stay inside repeat_buyers' independence check for
-# the sample drawn below too.
+# and makes 1-11 purchases; one-time buyers arise naturally and get frequency 0. Keep the population
+# large enough that the sampled subset below still has a stable frequency/monetary correlation:
+# repeat_buyers checks it against a fixed threshold that a small sample crosses on noise alone.
 n_customers = 600
 epoch = np.datetime64("2023-01-01")
 last_day_offset = 364  # 2023-12-31
@@ -84,5 +84,5 @@ covariate_cols = clv_covariates.covariate_cols
 
 # Feed to pymc-marketing (install separately): fit ParetoNBDModel on train.df and GammaGammaModel on
 # train_repeat_buyers, then score the full population with clv.df / repeat_buyers, passing time_unit
-# for finite-horizon CLV. For covariates, fit on clv_covariates (or a sample of it) and pass
-# covariate_cols as ParetoNBDModel's purchase/dropout covariate columns.
+# for finite-horizon CLV. For covariates, pass summary_covariates (or clv_covariates.sample(...).df)
+# as ParetoNBDModel's data and covariate_cols as its purchase/dropout covariate columns.

--- a/openretailscience/.agents/skills/using-openretailscience/scripts/example_clv_stats.py
+++ b/openretailscience/.agents/skills/using-openretailscience/scripts/example_clv_stats.py
@@ -53,13 +53,13 @@ clv = CLVStats(transactions, period="week")
 # observation_period_end pins the window instead of defaulting to the latest transaction date.
 summary_asof = CLVStats(transactions, period="week", observation_period_end="2023-12-31").df
 
-# repeat_buyers (frequency > 0) is the GammaGammaModel input.
-repeat_buyers = clv.repeat_buyers
-
 # sample() draws a random customer subset as another CLVStats: fit on it, score everyone from clv.df.
 # Pass n (exact count) or frac (share), never both; the draw is deterministic given random_state.
 train = clv.sample(n=150)
-train_repeat_buyers = train.repeat_buyers  # the sample's GammaGammaModel input
+train_repeat_buyers = train.repeat_buyers  # frequency > 0: the GammaGammaModel fitting input
+
+# The same property over the full population: the frame fitted spend is scored on.
+repeat_buyers = clv.repeat_buyers
 
 # pymc_time_unit ("W" here) is the time_unit for expected_customer_lifetime_value; its default "D"
 # silently misreads a weekly/monthly horizon.
@@ -82,7 +82,7 @@ summary_covariates = clv_covariates.df
 # covariate_cols = the attached columns (one-hot dummies + stores_shopped) to pass as covariates.
 covariate_cols = clv_covariates.covariate_cols
 
-# Feed to pymc-marketing (install separately): summary_covariates -> ParetoNBDModel, repeat_buyers ->
-# GammaGammaModel (pass time_unit for finite-horizon CLV), summary_covariates + covariate_cols ->
-# ParetoNBDModel covariates. To fit on a sample, fit on train.df / train_repeat_buyers and predict on
-# clv.df.
+# Feed to pymc-marketing (install separately): fit ParetoNBDModel on train.df and GammaGammaModel on
+# train_repeat_buyers, then score the full population with clv.df / repeat_buyers, passing time_unit
+# for finite-horizon CLV. For covariates, fit on clv_covariates (or a sample of it) and pass
+# covariate_cols as ParetoNBDModel's purchase/dropout covariate columns.

--- a/openretailscience/.agents/skills/using-openretailscience/scripts/example_clv_stats.py
+++ b/openretailscience/.agents/skills/using-openretailscience/scripts/example_clv_stats.py
@@ -12,9 +12,11 @@ from openretailscience.experimental.clv import CLVStats
 
 rng = np.random.default_rng(42)
 
-# ~200 customers shopping across 2023. Each starts on a random day in the first ~200 days
-# and makes 1-11 purchases; one-time buyers arise naturally and get frequency 0.
-n_customers = 200
+# ~600 customers shopping across 2023. Each starts on a random day in the first ~200 days
+# and makes 1-11 purchases; one-time buyers arise naturally and get frequency 0. Enough customers
+# that the sampling noise in the frequency/monetary correlation stays well inside repeat_buyers'
+# independence check, for the full summary and for the sample drawn below alike.
+n_customers = 600
 epoch = np.datetime64("2023-01-01")
 last_day_offset = 364  # 2023-12-31
 
@@ -54,6 +56,12 @@ summary_asof = CLVStats(transactions, period="week", observation_period_end="202
 # repeat_buyers (frequency > 0) is the GammaGammaModel input.
 repeat_buyers = clv.repeat_buyers
 
+# sample() draws a random customer subset as another CLVStats, for fitting a model on a tractable
+# population and scoring everyone from clv.df. Pass n (exact count) or frac (share), never both;
+# selection is a deterministic hash of customer_id salted with random_state (default 42).
+train = clv.sample(n=150)
+train_repeat_buyers = train.repeat_buyers  # the sample's GammaGammaModel input
+
 # pymc_time_unit ("W" here) is the time_unit for expected_customer_lifetime_value; its default "D"
 # silently misreads a weekly/monthly horizon.
 time_unit = clv.pymc_time_unit
@@ -77,4 +85,5 @@ covariate_cols = clv_covariates.covariate_cols
 
 # Feed to pymc-marketing (install separately): summary_covariates -> ParetoNBDModel, repeat_buyers ->
 # GammaGammaModel (pass time_unit for finite-horizon CLV), summary_covariates + covariate_cols ->
-# ParetoNBDModel covariates.
+# ParetoNBDModel covariates. To fit on a sample, fit on train.df / train_repeat_buyers and predict on
+# clv.df.

--- a/openretailscience/experimental/clv.py
+++ b/openretailscience/experimental/clv.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import datetime
 import functools
 import warnings
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import ibis
 import pandas as pd
@@ -40,10 +40,16 @@ from openretailscience.core.validation import (
     ensure_columns,
     ensure_data_has_columns,
     ensure_ibis_table,
+    ensure_integer,
     ensure_period,
+    ensure_positive,
     ensure_tznaive_datetime,
+    ensure_unit_interval,
 )
 from openretailscience.options import ColumnHelper
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 def _coerce_to_date(value: str | datetime.date) -> datetime.date:
@@ -189,6 +195,9 @@ class CLVStats:
     #: assumes the two are independent, and a stronger correlation biases its spend estimates (0.10-0.15
     #: is the practical "weak enough" band in BTYD guidance).
     _MONETARY_FREQUENCY_CORR_WARN: ClassVar[float] = 0.15
+    #: Buckets the per-customer sampling hash is folded into, setting the resolution of ``frac``
+    #: (1e-6). Large enough that rounding never distorts a realistic sample share.
+    _SAMPLE_BUCKETS: ClassVar[int] = 1_000_000
     #: The base BTYD output columns (literal pymc-marketing names); anything else on the summary is a
     #: covariate attached via customer_attributes / one_hot_col. See ``covariate_cols``.
     _BASE_SUMMARY_COLUMNS: ClassVar[tuple[str, ...]] = ("customer_id", "frequency", "recency", "T", "monetary_value")
@@ -395,6 +404,64 @@ class CLVStats:
             "T",
             "monetary_value",
         )
+
+    def sample(self, *, n: int | None = None, frac: float | None = None, random_state: int = 42) -> Self:
+        """Draws a random sample of customers, as a new :class:`CLVStats` over the same summary.
+
+        For fitting a model on a tractable subset and scoring the full population: fit on
+        ``clv.sample(n=50_000)``, predict on ``clv.df``. Selection is a deterministic hash of
+        ``customer_id`` salted with ``random_state``, so the same arguments draw the same customers on
+        every execution (unlike a ``random()`` predicate, which re-rolls per execution and is unseeded
+        on several backends), while different ``random_state`` values draw independent samples.
+
+        Sampling the summary is equivalent to sampling customers before aggregating -- a customer's
+        summary row depends only on their own transactions -- so the one aggregate serves both the fit
+        and the scoring. Row order in the result is not meaningful.
+
+        Args:
+            n (int | None, optional): Number of customers to draw. Yields every customer if it exceeds
+                the population. Mutually exclusive with ``frac``. Defaults to ``None``.
+            frac (float | None, optional): Share of customers to draw, in (0, 1]. A per-customer
+                Bernoulli draw, so the count lands near ``frac`` * population rather than on it, and it
+                costs a single predicate instead of ``n``'s sort. Mutually exclusive with ``n``.
+                Defaults to ``None``.
+            random_state (int, optional): Seed for reproducible sampling. Defaults to 42.
+
+        Returns:
+            Self: A ``CLVStats`` over the sampled customers, with the same ``period`` and covariates.
+
+        Raises:
+            TypeError: If ``n`` or ``random_state`` is not an integer, or ``frac`` is not a number.
+            ValueError: If both or neither of ``n`` and ``frac`` are given, if ``n`` is not positive,
+                or if ``frac`` is outside (0, 1].
+        """
+        if (n is None) == (frac is None):
+            msg = "sample requires exactly one of n or frac."
+            raise ValueError(msg)
+        ensure_integer(random_state, "random_state")
+        # The id column is the literal "customer_id" here: __init__ renames it. Cast to string so the
+        # salt concatenates whatever the configured id type is.
+        key = (self.table["customer_id"].cast("string") + ibis.literal(f"::{random_state}")).hash()
+        if n is not None:
+            ensure_integer(n, "n")
+            ensure_positive(n, "n")
+            # Ordering by the hash is a pseudo-random permutation of customers, so the first n are a
+            # uniform sample; the backend runs it as a top-N. Order on the raw hash, not the bucketed
+            # value below, whose ties would make the cut ambiguous past _SAMPLE_BUCKETS customers.
+            sampled = self.table.order_by(key).limit(n)
+        else:
+            ensure_positive(frac, "frac")
+            ensure_unit_interval(frac, "frac")
+            # abs() after the modulo, not before: abs(-2**63) overflows int64.
+            bucket = (key % self._SAMPLE_BUCKETS).abs()
+            sampled = self.table.filter(bucket < int(frac * self._SAMPLE_BUCKETS))
+        # Bypass __init__: the summary is already built and validated, and the sample shares its state
+        # (period, table) wholesale. Constructing through __init__ would re-run the observation-window
+        # and attribute queries against a table that no longer holds transactions.
+        sample = object.__new__(type(self))
+        sample.period = self.period
+        sample.table = sampled
+        return sample
 
     @functools.cached_property
     def df(self) -> pd.DataFrame:

--- a/openretailscience/experimental/clv.py
+++ b/openretailscience/experimental/clv.py
@@ -195,8 +195,7 @@ class CLVStats:
     #: assumes the two are independent, and a stronger correlation biases its spend estimates (0.10-0.15
     #: is the practical "weak enough" band in BTYD guidance).
     _MONETARY_FREQUENCY_CORR_WARN: ClassVar[float] = 0.15
-    #: Buckets the per-customer sampling hash is folded into, setting the resolution of ``frac``
-    #: (1e-6). Large enough that rounding never distorts a realistic sample share.
+    #: The per-customer sampling hash is folded into this many buckets, setting ``frac``'s resolution.
     _SAMPLE_BUCKETS: ClassVar[int] = 1_000_000
     #: The base BTYD output columns (literal pymc-marketing names); anything else on the summary is a
     #: covariate attached via customer_attributes / one_hot_col. See ``covariate_cols``.
@@ -409,22 +408,17 @@ class CLVStats:
         """Draws a random sample of customers, as a new :class:`CLVStats` over the same summary.
 
         For fitting a model on a tractable subset and scoring the full population: fit on
-        ``clv.sample(n=50_000)``, predict on ``clv.df``. Selection is a deterministic hash of
-        ``customer_id`` salted with ``random_state``, so the same arguments draw the same customers on
-        every execution (unlike a ``random()`` predicate, which re-rolls per execution and is unseeded
-        on several backends), while different ``random_state`` values draw independent samples.
-
-        Sampling the summary is equivalent to sampling customers before aggregating -- a customer's
-        summary row depends only on their own transactions -- so the one aggregate serves both the fit
-        and the scoring. Row order in the result is not meaningful.
+        ``clv.sample(n=50_000)``, predict on ``clv.df``. Customers are selected by a deterministic hash
+        of ``customer_id`` salted with ``random_state``, so the same arguments always draw the same
+        customers and a different ``random_state`` draws an independent sample. Row order in the result
+        is not meaningful.
 
         Args:
             n (int | None, optional): Number of customers to draw. Yields every customer if it exceeds
                 the population. Mutually exclusive with ``frac``. Defaults to ``None``.
-            frac (float | None, optional): Share of customers to draw, in (0, 1]. A per-customer
-                Bernoulli draw, so the count lands near ``frac`` * population rather than on it, and it
-                costs a single predicate instead of ``n``'s sort. Mutually exclusive with ``n``.
-                Defaults to ``None``.
+            frac (float | None, optional): Share of customers to draw, in (0, 1]. Drawn per customer,
+                so the count lands near ``frac`` * population rather than on it, and it costs a single
+                predicate instead of ``n``'s sort. Mutually exclusive with ``n``. Defaults to ``None``.
             random_state (int, optional): Seed for reproducible sampling. Defaults to 42.
 
         Returns:
@@ -439,15 +433,15 @@ class CLVStats:
             msg = "sample requires exactly one of n or frac."
             raise ValueError(msg)
         ensure_integer(random_state, "random_state")
-        # The id column is the literal "customer_id" here: __init__ renames it. Cast to string so the
-        # salt concatenates whatever the configured id type is.
+        # The id column is the literal "customer_id" here (__init__ renames it); cast so the salt
+        # concatenates onto any id type.
         key = (self.table["customer_id"].cast("string") + ibis.literal(f"::{random_state}")).hash()
         if n is not None:
             ensure_integer(n, "n")
             ensure_positive(n, "n")
-            # Ordering by the hash is a pseudo-random permutation of customers, so the first n are a
-            # uniform sample; the backend runs it as a top-N. Order on the raw hash, not the bucketed
-            # value below, whose ties would make the cut ambiguous past _SAMPLE_BUCKETS customers.
+            # A hash ordering is a pseudo-random permutation, so the first n are a uniform sample.
+            # Order on the raw hash, not the bucket below, whose ties would blur the cut once the
+            # population exceeds _SAMPLE_BUCKETS.
             sampled = self.table.order_by(key).limit(n)
         else:
             ensure_positive(frac, "frac")
@@ -455,9 +449,8 @@ class CLVStats:
             # abs() after the modulo, not before: abs(-2**63) overflows int64.
             bucket = (key % self._SAMPLE_BUCKETS).abs()
             sampled = self.table.filter(bucket < int(frac * self._SAMPLE_BUCKETS))
-        # Bypass __init__: the summary is already built and validated, and the sample shares its state
-        # (period, table) wholesale. Constructing through __init__ would re-run the observation-window
-        # and attribute queries against a table that no longer holds transactions.
+        # Bypass __init__, which would re-run the observation-window and attribute queries against a
+        # table that no longer holds transactions. (period, table) is the whole state.
         sample = object.__new__(type(self))
         sample.period = self.period
         sample.table = sampled

--- a/openretailscience/experimental/clv.py
+++ b/openretailscience/experimental/clv.py
@@ -139,13 +139,15 @@ class CLVStats:
     Aggregates transaction data into the ``frequency`` / ``recency`` / ``T`` /
     ``monetary_value`` summary that ``ParetoNBDModel`` and ``GammaGammaModel`` consume.
     Results are accessible via the ``table`` attribute (ibis Table) or the ``df`` property
-    (materialized pandas DataFrame). See the module docstring for column definitions.
+    (materialized pandas DataFrame); :meth:`sample` narrows the summary to a subset of customers to
+    fit on. See the module docstring for column definitions.
 
-    Constructing ``CLVStats`` runs one aggregate query against the backend to resolve and
-    validate the observation window (plus, when ``customer_attributes`` is given, one aggregate to
-    check its customer_id is unique and a single distinct-value query enumerating all ``one_hot_col``
-    categories); the full per-customer summary stays lazy and is materialized only on first
-    ``df`` access.
+    Constructing ``CLVStats`` from transactions runs one aggregate query against the backend to
+    resolve and validate the observation window (plus, when ``customer_attributes`` is given, one
+    aggregate to check its customer_id is unique and a single distinct-value query enumerating all
+    ``one_hot_col`` categories); the full per-customer summary stays lazy and is materialized only on
+    first ``df`` access. A :meth:`sample` result is built from an existing summary and queries nothing
+    until its own ``df`` is read.
 
     Args:
         data (pd.DataFrame | ibis.Table): Transaction data with the ``customer_id``,
@@ -409,16 +411,28 @@ class CLVStats:
 
         For fitting a model on a tractable subset and scoring the full population: fit on
         ``clv.sample(n=50_000)``, predict on ``clv.df``. Customers are selected by a deterministic hash
-        of ``customer_id`` salted with ``random_state``, so the same arguments always draw the same
-        customers and a different ``random_state`` draws an independent sample. Row order in the result
-        is not meaningful.
+        of ``customer_id`` salted with ``random_state``. Row order in the result is not meaningful.
+
+        Two properties the workflow depends on:
+
+        - The key is the *backend's* hash, so a draw repeats only for the same engine at the same
+          version (DuckDB's ``HASH`` output changes between releases). Record the drawn ids, not the
+          seed, when a fit has to be reproduced later. A backend with no Ibis ``hash`` rule (SQLite,
+          MySQL, Trino, Athena) raises ``OperationNotDefinedError`` on :attr:`df`, not here, because
+          the sample is a lazy expression.
+        - Draws nest rather than partition: at one ``random_state``, ``sample(frac=0.2)`` is a subset of
+          ``sample(frac=0.8)`` and re-sampling a sample returns it unchanged. A different
+          ``random_state`` re-draws independently, which still overlaps, so neither argument yields a
+          disjoint train/holdout split.
 
         Args:
             n (int | None, optional): Number of customers to draw. Yields every customer if it exceeds
                 the population. Mutually exclusive with ``frac``. Defaults to ``None``.
-            frac (float | None, optional): Share of customers to draw, in (0, 1]. Drawn per customer,
-                so the count lands near ``frac`` * population rather than on it, and it costs a single
-                predicate instead of ``n``'s sort. Mutually exclusive with ``n``. Defaults to ``None``.
+            frac (float | None, optional): Share of customers to draw, in (0, 1]; a share finer than
+                the sampling hash's bucket resolution is rejected rather than silently drawing nothing.
+                Drawn per customer, so the count lands near ``frac`` * population rather than on it,
+                and it costs a single predicate instead of ``n``'s sort. Mutually exclusive with ``n``.
+                Defaults to ``None``.
             random_state (int, optional): Seed for reproducible sampling. Defaults to 42.
 
         Returns:
@@ -427,7 +441,7 @@ class CLVStats:
         Raises:
             TypeError: If ``n`` or ``random_state`` is not an integer, or ``frac`` is not a number.
             ValueError: If both or neither of ``n`` and ``frac`` are given, if ``n`` is not positive,
-                or if ``frac`` is outside (0, 1].
+                or if ``frac`` is outside (0, 1] or finer than the bucket resolution.
         """
         if (n is None) == (frac is None):
             msg = "sample requires exactly one of n or frac."
@@ -436,19 +450,30 @@ class CLVStats:
         # The id column is the literal "customer_id" here (__init__ renames it); cast so the salt
         # concatenates onto any id type.
         key = (self.table["customer_id"].cast("string") + ibis.literal(f"::{random_state}")).hash()
+        # abs() after the modulo, not before: abs(-2**63) overflows int64. Both selectors rank on the
+        # bucket rather than the raw hash: SQL Server compiles ``hash`` to CHECKSUM, a rotate-xor whose
+        # high bits track the id's leading characters, so ordering on the raw key returns a contiguous
+        # block of sequential ids -- one signup cohort, not a sample. The modulo keeps only the low
+        # bits, which are well mixed even there.
+        bucket = (key % self._SAMPLE_BUCKETS).abs()
         if n is not None:
             ensure_integer(n, "n")
             ensure_positive(n, "n")
-            # A hash ordering is a pseudo-random permutation, so the first n are a uniform sample.
-            # Order on the raw hash, not the bucket below, whose ties would blur the cut once the
-            # population exceeds _SAMPLE_BUCKETS.
-            sampled = self.table.order_by(key).limit(n)
+            # Taking the n smallest buckets is the frac predicate with the cut solved for n. customer_id
+            # makes the order total: the boundary bucket holds population/_SAMPLE_BUCKETS customers, and
+            # an untied ORDER BY would return a different n per execution.
+            sampled = self.table.order_by([bucket, self.table["customer_id"]]).limit(n)
         else:
             ensure_positive(frac, "frac")
             ensure_unit_interval(frac, "frac")
-            # abs() after the modulo, not before: abs(-2**63) overflows int64.
-            bucket = (key % self._SAMPLE_BUCKETS).abs()
-            sampled = self.table.filter(bucket < int(frac * self._SAMPLE_BUCKETS))
+            cut = int(frac * self._SAMPLE_BUCKETS)
+            if cut == 0:
+                msg = (
+                    f"frac must be at least {1 / self._SAMPLE_BUCKETS} (the sampling hash resolution); "
+                    f"{frac} rounds to zero buckets, which would draw no customers. Use n for a smaller share."
+                )
+                raise ValueError(msg)
+            sampled = self.table.filter(bucket < cut)
         # Bypass __init__, which would re-run the observation-window and attribute queries against a
         # table that no longer holds transactions. (period, table) is the whole state.
         sample = object.__new__(type(self))

--- a/tests/experimental/test_clv.py
+++ b/tests/experimental/test_clv.py
@@ -736,16 +736,12 @@ class TestCLVStatsCustomerIdColumn:
 SAMPLE_POPULATION = 1000
 SAMPLE_N = 250
 SAMPLE_FRAC = 0.25
-# frac draws per customer, so the count varies around the expectation. Five standard deviations keeps
-# the bound independent of the backend's hash while still failing on a systematically wrong share.
-_EXPECTED_DRAWN = SAMPLE_FRAC * SAMPLE_POPULATION
-_DRAWN_TOLERANCE = 5 * np.sqrt(SAMPLE_POPULATION * SAMPLE_FRAC * (1 - SAMPLE_FRAC))
 # Two independent draws overlap in ~SAMPLE_FRAC of either one; a near-0 or near-1 share would mean
 # random_state partitions the population rather than re-drawing from it.
 _MIN_CROSS_SEED_OVERLAP = 0.10
 _MAX_CROSS_SEED_OVERLAP = 0.45
-# Standard errors of tolerance for a sample statistic, matching _DRAWN_TOLERANCE's bound: wide enough
-# that an unbiased draw never trips it on a backend hash change, tight enough to fail on real skew.
+# Standard errors of tolerance for a sample statistic: wide enough that an unbiased draw never trips it
+# on a backend hash change, tight enough to fail on a systematically wrong share or a skewed draw.
 _SAMPLE_STAT_SIGMAS = 5
 # For tests that need only which customers were drawn, not the distribution of the draw.
 _SMALL_POPULATION = 200
@@ -785,11 +781,12 @@ class TestCLVStatsSample:
         """A CLVStats over SAMPLE_POPULATION customers; every test in the class only reads it."""
         return CLVStats(_many_customers(), period="week")
 
-    def test_sample_n_returns_exactly_n_customers(self, clv):
+    @pytest.mark.parametrize("n", [1, SAMPLE_N], ids=["single-customer", "many-customers"])
+    def test_sample_n_returns_exactly_n_customers(self, clv, n):
         """An n draw yields that exact number of customers, all of them from the full summary."""
-        sample = clv.sample(n=SAMPLE_N)
+        sample = clv.sample(n=n)
 
-        assert len(sample.df) == SAMPLE_N
+        assert len(sample.df) == n
         assert set(sample.df["customer_id"]) <= set(clv.df["customer_id"])
 
     @pytest.mark.parametrize(
@@ -801,11 +798,13 @@ class TestCLVStatsSample:
         """An n above the population, or frac=1.0, yields the whole summary rather than an error."""
         assert set(clv.sample(**kwargs).df["customer_id"]) == set(clv.df["customer_id"])
 
-    def test_sample_frac_draws_approximately_the_requested_share(self, clv):
-        """A frac draw is per-customer, so the row count lands near frac * population."""
-        drawn = len(clv.sample(frac=SAMPLE_FRAC).df)
+    @pytest.mark.parametrize("frac", [0.1, SAMPLE_FRAC, 0.5])
+    def test_sample_frac_draws_approximately_the_requested_share(self, clv, frac):
+        """The drawn count tracks frac across its range, landing near frac * population, not on it."""
+        expected = frac * SAMPLE_POPULATION
+        tolerance = _SAMPLE_STAT_SIGMAS * np.sqrt(SAMPLE_POPULATION * frac * (1 - frac))
 
-        assert abs(drawn - _EXPECTED_DRAWN) <= _DRAWN_TOLERANCE
+        assert abs(len(clv.sample(frac=frac).df) - expected) <= tolerance
 
     @pytest.mark.parametrize("kwargs", [{"n": SAMPLE_N}, {"frac": SAMPLE_FRAC}])
     def test_sample_is_deterministic_for_a_given_random_state(self, clv, kwargs):

--- a/tests/experimental/test_clv.py
+++ b/tests/experimental/test_clv.py
@@ -106,6 +106,18 @@ class TestCLVStats:
         with pytest.raises(TypeError, match="date or datetime"):
             CLVStats(data)
 
+    def test_empty_data_raises_clear_error(self):
+        """Empty transaction data raises a clear ValueError, not a misleading date-coercion TypeError."""
+        empty = pd.DataFrame(
+            {
+                cols.customer_id: pd.Series([], dtype="int64"),
+                cols.transaction_date: pd.Series([], dtype="datetime64[ns]"),
+                cols.unit_spend: pd.Series([], dtype="float64"),
+            },
+        )
+        with pytest.raises(ValueError, match="no transactions"):
+            CLVStats(empty)
+
     def test_null_transaction_date_rows_are_dropped(self):
         """Rows with a NULL transaction_date are dropped.
 
@@ -171,16 +183,32 @@ class TestCLVStats:
         )
         assert_frame_equal(result, expected)
 
-    @pytest.mark.parametrize("bad_period", ["fortnight", "year", "quarter"])
-    def test_invalid_period_raises(self, bad_period):
-        """Periods outside day/week/month are rejected (year/quarter are real words but unsupported here)."""
-        with pytest.raises(ValueError, match="period"):
-            CLVStats(_transactions(), period=bad_period)
-
-    def test_observation_period_end_before_last_purchase_raises(self):
-        """An observation_period_end earlier than a customer's last purchase is rejected."""
-        with pytest.raises(ValueError, match="observation_period_end"):
-            CLVStats(_transactions(), observation_period_end="2023-01-10")
+    @pytest.mark.parametrize(
+        ("kwargs", "error", "match"),
+        [
+            # year/quarter are real period words, but unsupported here.
+            pytest.param({"period": "fortnight"}, ValueError, "period", id="period-not-a-word"),
+            pytest.param({"period": "year"}, ValueError, "period", id="period-year"),
+            pytest.param({"period": "quarter"}, ValueError, "period", id="period-quarter"),
+            # An end before a customer's last purchase would give them a negative age.
+            pytest.param(
+                {"observation_period_end": "2023-01-10"},
+                ValueError,
+                "observation_period_end",
+                id="obs-end-before-last-purchase",
+            ),
+            pytest.param(
+                {"observation_period_end": 20230129},
+                TypeError,
+                "observation_period_end",
+                id="obs-end-not-a-date",
+            ),
+        ],
+    )
+    def test_invalid_construction_argument_raises(self, kwargs, error, match):
+        """A period or observation_period_end outside its contract is rejected at construction."""
+        with pytest.raises(error, match=match):
+            CLVStats(_transactions(), **kwargs)
 
     def test_observation_period_end_equal_to_latest_is_allowed(self):
         """An observation_period_end exactly on the latest transaction is accepted (guard is strict <)."""
@@ -191,11 +219,6 @@ class TestCLVStats:
             explicit.sort_values(cols.customer_id).reset_index(drop=True),
             default.sort_values(cols.customer_id).reset_index(drop=True),
         )
-
-    def test_observation_period_end_invalid_type_raises(self):
-        """A non-date observation_period_end (e.g. an int) is rejected with TypeError."""
-        with pytest.raises(TypeError, match="observation_period_end"):
-            CLVStats(_transactions(), observation_period_end=20230129)
 
     def test_repeat_buyers_keeps_only_repeat_buyers(self):
         """repeat_buyers is the GammaGamma-ready subset: the repeat buyers (frequency > 0).
@@ -572,18 +595,6 @@ class TestCLVStatsCustomerAttributes:
         )
         assert_frame_equal(dummies, expected_dummies)
 
-    def test_empty_data_raises_clear_error(self):
-        """Empty transaction data raises a clear ValueError, not a misleading date-coercion TypeError."""
-        empty = pd.DataFrame(
-            {
-                cols.customer_id: pd.Series([], dtype="int64"),
-                cols.transaction_date: pd.Series([], dtype="datetime64[ns]"),
-                cols.unit_spend: pd.Series([], dtype="float64"),
-            },
-        )
-        with pytest.raises(ValueError, match="no transactions"):
-            CLVStats(empty)
-
     def test_duplicate_one_hot_col_is_deduplicated(self):
         """A repeated one_hot_col is de-duplicated, not encoded twice (which would drop-then-not-find it)."""
         transactions = pd.DataFrame(
@@ -837,8 +848,8 @@ class TestCLVStatsSample:
         assert set(repeat_buyers["customer_id"]) < set(clv.repeat_buyers["customer_id"])
         assert_frame_equal(repeat_buyers, sample.df[sample.df["frequency"] > 0].reset_index(drop=True))
 
-    def test_sample_keeps_covariate_columns(self):
-        """Covariates attached to the full summary survive into the sample, one-hot dummies included."""
+    def test_sample_keeps_each_customers_covariate_values(self):
+        """Covariates attached to the full summary reach the sample unchanged, one-hot dummies included."""
         transactions = _many_customers(_SMALL_POPULATION)
         customer_ids = transactions[cols.customer_id].drop_duplicates().to_numpy()
         attributes = pd.DataFrame(

--- a/tests/experimental/test_clv.py
+++ b/tests/experimental/test_clv.py
@@ -733,19 +733,27 @@ _DRAWN_TOLERANCE = 5 * np.sqrt(SAMPLE_POPULATION * SAMPLE_FRAC * (1 - SAMPLE_FRA
 # random_state partitions the population rather than re-drawing from it.
 _MIN_CROSS_SEED_OVERLAP = 0.10
 _MAX_CROSS_SEED_OVERLAP = 0.45
-# The population mean frequency is ~2.5; a sample skewed toward one end of the id range would drift
-# further than this.
-_UNBIASED_FREQUENCY_TOLERANCE = 0.15
+# Standard errors of tolerance for a sample statistic, matching _DRAWN_TOLERANCE's bound: wide enough
+# that an unbiased draw never trips it on a backend hash change, tight enough to fail on real skew.
+_SAMPLE_STAT_SIGMAS = 5
 # For tests that need only which customers were drawn, not the distribution of the draw.
 _SMALL_POPULATION = 200
 _SMALL_SAMPLE_N = 50
+_SMALL_SAMPLE_FRAC = 0.5
+# Purchase days per customer run 1.._MAX_PURCHASE_DAYS across the id range in _many_customers.
+_MAX_PURCHASE_DAYS = 6
 
 
 def _many_customers(n_customers: int = SAMPLE_POPULATION) -> pd.DataFrame:
-    """Transaction data for ``n_customers`` customers with 1-6 purchase days each."""
+    """Transaction data for ``n_customers`` customers with 1-6 purchase days each.
+
+    Ids are issued in signup order and purchase count rises with tenure, so any draw biased toward one
+    end of the id range has a visibly different mean frequency than the population — which is what
+    ``test_sample_is_unbiased_with_respect_to_frequency`` relies on to have teeth.
+    """
     rng = np.random.default_rng(42)
     customer_ids = np.arange(10_001, 10_001 + n_customers)
-    purchase_days = rng.integers(1, 7, size=n_customers)
+    purchase_days = 1 + np.arange(n_customers) * _MAX_PURCHASE_DAYS // n_customers
     repeated_ids = np.repeat(customer_ids, purchase_days)
     day_offsets = rng.integers(0, 180, size=repeated_ids.size)
     return pd.DataFrame(
@@ -760,9 +768,10 @@ def _many_customers(n_customers: int = SAMPLE_POPULATION) -> pd.DataFrame:
 class TestCLVStatsSample:
     """Tests for CLVStats.sample -- the fit-on-a-sample, score-on-everyone workflow."""
 
-    @pytest.fixture
-    def clv(self) -> CLVStats:
-        """A CLVStats over SAMPLE_POPULATION customers."""
+    @pytest.fixture(scope="class")
+    @classmethod
+    def clv(cls) -> CLVStats:
+        """A CLVStats over SAMPLE_POPULATION customers; every test in the class only reads it."""
         return CLVStats(_many_customers(), period="week")
 
     def test_sample_n_returns_exactly_n_customers(self, clv):
@@ -772,9 +781,14 @@ class TestCLVStatsSample:
         assert len(sample.df) == SAMPLE_N
         assert set(sample.df["customer_id"]) <= set(clv.df["customer_id"])
 
-    def test_sample_n_above_customer_count_returns_every_customer(self, clv):
-        """An n larger than the population yields the whole summary rather than an error."""
-        assert set(clv.sample(n=SAMPLE_POPULATION * 5).df["customer_id"]) == set(clv.df["customer_id"])
+    @pytest.mark.parametrize(
+        "kwargs",
+        [{"n": SAMPLE_POPULATION * 5}, {"frac": 1.0}],
+        ids=["n-above-population", "frac-of-one"],
+    )
+    def test_a_selector_covering_the_population_returns_every_customer(self, clv, kwargs):
+        """An n above the population, or frac=1.0, yields the whole summary rather than an error."""
+        assert set(clv.sample(**kwargs).df["customer_id"]) == set(clv.df["customer_id"])
 
     def test_sample_frac_draws_approximately_the_requested_share(self, clv):
         """A frac draw is per-customer, so the row count lands near frac * population."""
@@ -803,11 +817,14 @@ class TestCLVStatsSample:
         assert_frame_equal(sample, expected)
 
     def test_sample_is_unbiased_with_respect_to_frequency(self, clv):
-        """The draw is random rather than a biased head: sampled frequency tracks the population."""
-        sample_mean = clv.sample(frac=SAMPLE_FRAC).df["frequency"].mean()
-        population_mean = clv.df["frequency"].mean()
+        """The draw is random rather than a slice of the id range: sampled frequency tracks the population."""
+        sample = clv.sample(frac=SAMPLE_FRAC).df
+        population = clv.df["frequency"]
+        # Frequency rises with customer_id in this fixture, so an id-ordered slice shifts the mean by
+        # ~2 purchases -- far outside a tolerance set at the sample mean's own standard error.
+        tolerance = _SAMPLE_STAT_SIGMAS * population.std() / np.sqrt(len(sample))
 
-        assert abs(sample_mean - population_mean) < _UNBIASED_FREQUENCY_TOLERANCE
+        assert abs(sample["frequency"].mean() - population.mean()) < tolerance
 
     def test_sample_returns_a_clvstats_carrying_period_and_repeat_buyers(self, clv):
         """The sample is itself a CLVStats: same period, and repeat_buyers scoped to the sample."""
@@ -816,6 +833,8 @@ class TestCLVStatsSample:
 
         assert sample.period == clv.period
         assert sample.pymc_time_unit == clv.pymc_time_unit
+        # A proper subset of the population's repeat buyers: fails if sample() handed back self.
+        assert set(repeat_buyers["customer_id"]) < set(clv.repeat_buyers["customer_id"])
         assert_frame_equal(repeat_buyers, sample.df[sample.df["frequency"] > 0].reset_index(drop=True))
 
     def test_sample_keeps_covariate_columns(self):
@@ -830,20 +849,25 @@ class TestCLVStatsSample:
             },
         )
         clv = CLVStats(transactions, customer_attributes=attributes, one_hot_col="signup_channel")
-        sample = clv.sample(frac=0.5)
+        sample = clv.sample(frac=_SMALL_SAMPLE_FRAC).df.sort_values("customer_id").reset_index(drop=True)
+        expected = clv.df.set_index("customer_id").loc[sample["customer_id"]].reset_index()
 
-        assert sample.covariate_cols == clv.covariate_cols
-        assert list(sample.df.columns) == list(clv.df.columns)
+        assert clv.covariate_cols == ["stores_shopped", "signup_channel_online"]
+        # Values, not just column names: a sample must carry each customer's covariates unchanged.
+        assert_frame_equal(sample, expected)
 
     def test_sample_uses_the_configured_customer_id_column(self):
-        """Sampling keys off the customer, not row position, under an overridden customer_id option."""
-        transactions = _many_customers(_SMALL_POPULATION).rename(columns={cols.customer_id: "cust"})
+        """An overridden customer_id option draws the same customers as the default one."""
+        transactions = _many_customers(_SMALL_POPULATION)
+        default_draw = set(CLVStats(transactions).sample(n=_SMALL_SAMPLE_N).df["customer_id"])
         with option_context("column.customer_id", "cust"):
-            clv = CLVStats(transactions)
-            sample = clv.sample(n=_SMALL_SAMPLE_N)
+            renamed = CLVStats(transactions.rename(columns={cols.customer_id: "cust"}))
+            sample = renamed.sample(n=_SMALL_SAMPLE_N)
 
-        assert len(sample.df) == _SMALL_SAMPLE_N
-        assert set(sample.df["customer_id"]) <= set(clv.df["customer_id"])
+        # Equality (not subset) pins the draw to the id values: a positional limit would instead
+        # follow the frame's row order, which the rename does not change.
+        assert set(sample.df["customer_id"]) == default_draw
+        assert len(default_draw) == _SMALL_SAMPLE_N
 
     @pytest.mark.parametrize(
         ("kwargs", "error", "match"),
@@ -852,6 +876,7 @@ class TestCLVStatsSample:
             pytest.param({"n": 10, "frac": 0.1}, ValueError, "exactly one of n or frac", id="both"),
             pytest.param({"frac": 0.0}, ValueError, "frac must be positive", id="frac-zero"),
             pytest.param({"frac": 1.5}, ValueError, "frac must be between 0 and 1", id="frac-above-one"),
+            pytest.param({"frac": 1e-7}, ValueError, "rounds to zero buckets", id="frac-below-resolution"),
             pytest.param({"n": 0}, ValueError, "n must be positive", id="n-zero"),
             pytest.param({"n": 10.5}, TypeError, "n must be an integer", id="n-float"),
             pytest.param({"n": 10, "random_state": 1.5}, TypeError, "random_state must be an integer", id="seed-float"),
@@ -862,6 +887,9 @@ class TestCLVStatsSample:
         with pytest.raises(error, match=match):
             clv.sample(**kwargs)
 
-    def test_frac_of_one_returns_every_customer(self, clv):
-        """frac=1.0 keeps the whole population (the inclusive boundary of the unit interval)."""
-        assert set(clv.sample(frac=1.0).df["customer_id"]) == set(clv.df["customer_id"])
+    @pytest.mark.parametrize("kwargs", [{"n": SAMPLE_N}, {"frac": SAMPLE_FRAC}])
+    def test_resampling_at_the_same_seed_nests_rather_than_narrows(self, clv, kwargs):
+        """A same-seed draw over a sample re-selects it whole, so chained calls do not compound."""
+        sample = clv.sample(**kwargs)
+
+        assert set(sample.sample(**kwargs).df["customer_id"]) == set(sample.df["customer_id"])

--- a/tests/experimental/test_clv.py
+++ b/tests/experimental/test_clv.py
@@ -718,3 +718,151 @@ class TestCLVStatsCustomerIdColumn:
             )
             with pytest.raises(ValueError, match="reserved BTYD"):
                 CLVStats(self._txns("shopper_id"), period="day", customer_attributes=attributes)
+
+
+# Sampling behaviour (share drawn, unbiasedness) is only observable over a population, so the sampling
+# tests use a generated one rather than the hand-computed fixture above.
+SAMPLE_POPULATION = 1000
+SAMPLE_N = 250
+SAMPLE_FRAC = 0.25
+# frac is a per-customer Bernoulli draw, so the count varies around SAMPLE_FRAC * SAMPLE_POPULATION.
+# Five standard deviations keeps the bound independent of the backend's hash function while still
+# failing on a systematically wrong share.
+_EXPECTED_DRAWN = SAMPLE_FRAC * SAMPLE_POPULATION
+_DRAWN_TOLERANCE = 5 * np.sqrt(SAMPLE_POPULATION * SAMPLE_FRAC * (1 - SAMPLE_FRAC))
+# Two independent SAMPLE_FRAC draws overlap in ~SAMPLE_FRAC of either one; a near-0 or near-1 share
+# would mean random_state is partitioning the population rather than re-drawing from it.
+_MIN_CROSS_SEED_OVERLAP = 0.10
+_MAX_CROSS_SEED_OVERLAP = 0.45
+# The population mean frequency is ~2.5 (1-6 purchase days per customer); a head-of-table sample
+# ordered by anything correlated with the id would drift further than this.
+_UNBIASED_FREQUENCY_TOLERANCE = 0.15
+# A smaller population for tests that only need the sample's identity, not its distribution.
+_SMALL_POPULATION = 200
+_SMALL_SAMPLE_N = 50
+
+
+def _many_customers(n_customers: int = SAMPLE_POPULATION) -> pd.DataFrame:
+    """Transaction data for ``n_customers`` customers with 1-6 purchase days each."""
+    rng = np.random.default_rng(42)
+    customer_ids = np.arange(10_001, 10_001 + n_customers)
+    purchase_days = rng.integers(1, 7, size=n_customers)
+    repeated_ids = np.repeat(customer_ids, purchase_days)
+    day_offsets = rng.integers(0, 180, size=repeated_ids.size)
+    return pd.DataFrame(
+        {
+            cols.customer_id: repeated_ids,
+            cols.transaction_date: pd.Timestamp("2023-01-01") + pd.to_timedelta(day_offsets, unit="D"),
+            cols.unit_spend: np.round(rng.uniform(10.0, 200.0, size=repeated_ids.size), 2),
+        },
+    )
+
+
+class TestCLVStatsSample:
+    """Tests for CLVStats.sample -- the fit-on-a-sample, score-on-everyone workflow."""
+
+    @pytest.fixture
+    def clv(self) -> CLVStats:
+        """A CLVStats over SAMPLE_POPULATION customers."""
+        return CLVStats(_many_customers(), period="week")
+
+    def test_sample_n_returns_exactly_n_customers(self, clv):
+        """An n draw yields that exact number of customers, all of them from the full summary."""
+        sample = clv.sample(n=SAMPLE_N)
+
+        assert len(sample.df) == SAMPLE_N
+        assert set(sample.df["customer_id"]) <= set(clv.df["customer_id"])
+
+    def test_sample_n_above_customer_count_returns_every_customer(self, clv):
+        """An n larger than the population yields the whole summary rather than an error."""
+        assert set(clv.sample(n=SAMPLE_POPULATION * 5).df["customer_id"]) == set(clv.df["customer_id"])
+
+    def test_sample_frac_draws_approximately_the_requested_share(self, clv):
+        """A frac draw is per-customer, so the row count lands near frac * population."""
+        drawn = len(clv.sample(frac=SAMPLE_FRAC).df)
+
+        assert abs(drawn - _EXPECTED_DRAWN) <= _DRAWN_TOLERANCE
+
+    @pytest.mark.parametrize("kwargs", [{"n": SAMPLE_N}, {"frac": SAMPLE_FRAC}])
+    def test_sample_is_deterministic_for_a_given_random_state(self, clv, kwargs):
+        """Re-sampling with the same random_state draws exactly the same customers."""
+        assert set(clv.sample(**kwargs).df["customer_id"]) == set(clv.sample(**kwargs).df["customer_id"])
+
+    @pytest.mark.parametrize("kwargs", [{"n": SAMPLE_N}, {"frac": SAMPLE_FRAC}])
+    def test_different_random_state_draws_a_different_sample(self, clv, kwargs):
+        """A different random_state draws an independent sample, not an identical or disjoint one."""
+        first = set(clv.sample(random_state=1, **kwargs).df["customer_id"])
+        second = set(clv.sample(random_state=2, **kwargs).df["customer_id"])
+
+        assert _MIN_CROSS_SEED_OVERLAP <= len(first & second) / len(first) <= _MAX_CROSS_SEED_OVERLAP
+
+    def test_sampled_rows_are_the_unmodified_summary_rows(self, clv):
+        """Sampling selects customers; it never recomputes or alters a customer's summary."""
+        sample = clv.sample(n=SAMPLE_N).df.sort_values("customer_id").reset_index(drop=True)
+        expected = clv.df.set_index("customer_id").loc[sample["customer_id"]].reset_index()
+
+        assert_frame_equal(sample, expected)
+
+    def test_sample_is_unbiased_with_respect_to_frequency(self, clv):
+        """The draw is random rather than a biased head: sampled frequency tracks the population."""
+        sample_mean = clv.sample(frac=SAMPLE_FRAC).df["frequency"].mean()
+        population_mean = clv.df["frequency"].mean()
+
+        assert abs(sample_mean - population_mean) < _UNBIASED_FREQUENCY_TOLERANCE
+
+    def test_sample_returns_a_clvstats_carrying_period_and_repeat_buyers(self, clv):
+        """The sample is itself a CLVStats: same period, and repeat_buyers scoped to the sample."""
+        sample = clv.sample(n=SAMPLE_N)
+        repeat_buyers = sample.repeat_buyers
+
+        assert sample.period == clv.period
+        assert sample.pymc_time_unit == clv.pymc_time_unit
+        assert_frame_equal(repeat_buyers, sample.df[sample.df["frequency"] > 0].reset_index(drop=True))
+
+    def test_sample_keeps_covariate_columns(self):
+        """Covariates attached to the full summary survive into the sample, one-hot dummies included."""
+        transactions = _many_customers(_SMALL_POPULATION)
+        customer_ids = transactions[cols.customer_id].drop_duplicates().to_numpy()
+        attributes = pd.DataFrame(
+            {
+                cols.customer_id: customer_ids,
+                "stores_shopped": np.arange(len(customer_ids)) % 5 + 1,
+                "signup_channel": np.where(customer_ids % 2 == 0, "in_store", "online"),
+            },
+        )
+        clv = CLVStats(transactions, customer_attributes=attributes, one_hot_col="signup_channel")
+        sample = clv.sample(frac=0.5)
+
+        assert sample.covariate_cols == clv.covariate_cols
+        assert list(sample.df.columns) == list(clv.df.columns)
+
+    def test_sample_uses_the_configured_customer_id_column(self):
+        """Sampling keys off the customer, not row position, under an overridden customer_id option."""
+        transactions = _many_customers(_SMALL_POPULATION).rename(columns={cols.customer_id: "cust"})
+        with option_context("column.customer_id", "cust"):
+            clv = CLVStats(transactions)
+            sample = clv.sample(n=_SMALL_SAMPLE_N)
+
+        assert len(sample.df) == _SMALL_SAMPLE_N
+        assert set(sample.df["customer_id"]) <= set(clv.df["customer_id"])
+
+    @pytest.mark.parametrize(
+        ("kwargs", "error", "match"),
+        [
+            pytest.param({}, ValueError, "exactly one of n or frac", id="neither"),
+            pytest.param({"n": 10, "frac": 0.1}, ValueError, "exactly one of n or frac", id="both"),
+            pytest.param({"frac": 0.0}, ValueError, "frac must be positive", id="frac-zero"),
+            pytest.param({"frac": 1.5}, ValueError, "frac must be between 0 and 1", id="frac-above-one"),
+            pytest.param({"n": 0}, ValueError, "n must be positive", id="n-zero"),
+            pytest.param({"n": 10.5}, TypeError, "n must be an integer", id="n-float"),
+            pytest.param({"n": 10, "random_state": 1.5}, TypeError, "random_state must be an integer", id="seed-float"),
+        ],
+    )
+    def test_invalid_sample_arguments_raise(self, clv, kwargs, error, match):
+        """Bad selector or random_state arguments are rejected at the API boundary."""
+        with pytest.raises(error, match=match):
+            clv.sample(**kwargs)
+
+    def test_frac_of_one_returns_every_customer(self, clv):
+        """frac=1.0 keeps the whole population (the inclusive boundary of the unit interval)."""
+        assert set(clv.sample(frac=1.0).df["customer_id"]) == set(clv.df["customer_id"])

--- a/tests/experimental/test_clv.py
+++ b/tests/experimental/test_clv.py
@@ -720,24 +720,23 @@ class TestCLVStatsCustomerIdColumn:
                 CLVStats(self._txns("shopper_id"), period="day", customer_attributes=attributes)
 
 
-# Sampling behaviour (share drawn, unbiasedness) is only observable over a population, so the sampling
-# tests use a generated one rather than the hand-computed fixture above.
+# Share drawn and unbiasedness are only observable over a population, so these tests generate one
+# rather than reuse the hand-computed fixture above.
 SAMPLE_POPULATION = 1000
 SAMPLE_N = 250
 SAMPLE_FRAC = 0.25
-# frac is a per-customer Bernoulli draw, so the count varies around SAMPLE_FRAC * SAMPLE_POPULATION.
-# Five standard deviations keeps the bound independent of the backend's hash function while still
-# failing on a systematically wrong share.
+# frac draws per customer, so the count varies around the expectation. Five standard deviations keeps
+# the bound independent of the backend's hash while still failing on a systematically wrong share.
 _EXPECTED_DRAWN = SAMPLE_FRAC * SAMPLE_POPULATION
 _DRAWN_TOLERANCE = 5 * np.sqrt(SAMPLE_POPULATION * SAMPLE_FRAC * (1 - SAMPLE_FRAC))
-# Two independent SAMPLE_FRAC draws overlap in ~SAMPLE_FRAC of either one; a near-0 or near-1 share
-# would mean random_state is partitioning the population rather than re-drawing from it.
+# Two independent draws overlap in ~SAMPLE_FRAC of either one; a near-0 or near-1 share would mean
+# random_state partitions the population rather than re-drawing from it.
 _MIN_CROSS_SEED_OVERLAP = 0.10
 _MAX_CROSS_SEED_OVERLAP = 0.45
-# The population mean frequency is ~2.5 (1-6 purchase days per customer); a head-of-table sample
-# ordered by anything correlated with the id would drift further than this.
+# The population mean frequency is ~2.5; a sample skewed toward one end of the id range would drift
+# further than this.
 _UNBIASED_FREQUENCY_TOLERANCE = 0.15
-# A smaller population for tests that only need the sample's identity, not its distribution.
+# For tests that need only which customers were drawn, not the distribution of the draw.
 _SMALL_POPULATION = 200
 _SMALL_SAMPLE_N = 50
 

--- a/tests/integration/test_clv_stats.py
+++ b/tests/integration/test_clv_stats.py
@@ -138,8 +138,8 @@ def test_clv_stats_sample_integration(transactions_table):
     """CLVStats.sample draws a deterministic customer subset on each backend.
 
     The sampling key compiles to a different hash function per engine (``ORA_HASH``, ``CHECKSUM``,
-    ``FARM_FINGERPRINT``, ``HASH``), and the ``frac`` path adds a portable ``ABS(MOD(...))``, so this
-    guards that selection stays valid SQL and stays stable across executions everywhere.
+    ``FARM_FINGERPRINT``, ``HASH``), and the ``frac`` path adds an ``ABS(MOD(...))``, so this guards
+    that selection stays valid SQL and stays stable across executions everywhere.
 
     Args:
         transactions_table: Parameterized fixture providing the transactions table on each backend.
@@ -152,8 +152,8 @@ def test_clv_stats_sample_integration(transactions_table):
 
     assert len(sampled.df) == _SAMPLE_CUSTOMERS
     assert sampled_ids <= all_customers
-    # Same random_state, same customers: a re-executed random() predicate would not hold here.
+    # Same random_state, same customers -- what a re-rolled random() predicate would fail.
     assert set(clv.sample(n=_SAMPLE_CUSTOMERS).df[cols.customer_id]) == sampled_ids
     assert set(clv.sample(n=_SUBSET_CUSTOMERS * 2).df[cols.customer_id]) == all_customers
-    # frac=1.0 exercises the modulo/abs predicate (rather than the order-by-hash path) portably.
+    # frac=1.0 exercises the modulo/abs predicate rather than the order-by-hash path.
     assert set(clv.sample(frac=1.0).df[cols.customer_id]) == all_customers

--- a/tests/integration/test_clv_stats.py
+++ b/tests/integration/test_clv_stats.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 cols = ColumnHelper()
 
 _SUBSET_CUSTOMERS = 25
+_SAMPLE_CUSTOMERS = 10
 
 
 def _subset(transactions_table: Table) -> Table:
@@ -131,3 +132,28 @@ def test_clv_stats_customer_attributes_and_one_hot_integration(transactions_tabl
         pd.testing.assert_series_equal(result[dummy], (max_store == value).astype("int8"), check_names=False)
     # A row flags at most one dummy (its max store); reference-level customers flag none.
     assert (result[store_dummies].sum(axis=1) <= 1).all()
+
+
+def test_clv_stats_sample_integration(transactions_table):
+    """CLVStats.sample draws a deterministic customer subset on each backend.
+
+    The sampling key compiles to a different hash function per engine (``ORA_HASH``, ``CHECKSUM``,
+    ``FARM_FINGERPRINT``, ``HASH``), and the ``frac`` path adds a portable ``ABS(MOD(...))``, so this
+    guards that selection stays valid SQL and stays stable across executions everywhere.
+
+    Args:
+        transactions_table: Parameterized fixture providing the transactions table on each backend.
+    """
+    clv = CLVStats(_subset(transactions_table), period="week")
+    all_customers = set(clv.df[cols.customer_id])
+
+    sampled = clv.sample(n=_SAMPLE_CUSTOMERS)
+    sampled_ids = set(sampled.df[cols.customer_id])
+
+    assert len(sampled.df) == _SAMPLE_CUSTOMERS
+    assert sampled_ids <= all_customers
+    # Same random_state, same customers: a re-executed random() predicate would not hold here.
+    assert set(clv.sample(n=_SAMPLE_CUSTOMERS).df[cols.customer_id]) == sampled_ids
+    assert set(clv.sample(n=_SUBSET_CUSTOMERS * 2).df[cols.customer_id]) == all_customers
+    # frac=1.0 exercises the modulo/abs predicate (rather than the order-by-hash path) portably.
+    assert set(clv.sample(frac=1.0).df[cols.customer_id]) == all_customers

--- a/tests/integration/test_clv_stats.py
+++ b/tests/integration/test_clv_stats.py
@@ -161,9 +161,5 @@ def test_clv_stats_sample_integration(transactions_table):
     # frac exercises the modulo/abs predicate rather than the order-by-hash path. A mid-range share
     # must land strictly inside the population: `bucket < _SAMPLE_BUCKETS` alone is true of any value
     # the predicate can produce, so frac=1.0 on its own would pass even on an engine selecting nothing.
-    half = set(clv.sample(frac=0.5).df[cols.customer_id])
-    assert set() < half < all_customers
+    assert set() < set(clv.sample(frac=0.5).df[cols.customer_id]) < all_customers
     assert set(clv.sample(frac=1.0).df[cols.customer_id]) == all_customers
-    # A real share pins the predicate's selectivity, which frac=1.0 cannot -- `bucket < 1_000_000`
-    # holds for any bucket, so a dropped ABS() on a signed-hash engine would pass unnoticed.
-    assert 0 < len(clv.sample(frac=0.5).df) < _SUBSET_CUSTOMERS

--- a/tests/integration/test_clv_stats.py
+++ b/tests/integration/test_clv_stats.py
@@ -139,7 +139,8 @@ def test_clv_stats_sample_integration(transactions_table):
 
     The sampling key compiles to a different hash function per engine (``ORA_HASH``, ``CHECKSUM``,
     ``FARM_FINGERPRINT``, ``HASH``), and the ``frac`` path adds an ``ABS(MOD(...))``, so this guards
-    that selection stays valid SQL and stays stable across executions everywhere.
+    that selection stays valid SQL and stays stable across executions everywhere. Row counts and the
+    ``n`` > population case are covered locally; only the per-engine SQL needs a round trip.
 
     Args:
         transactions_table: Parameterized fixture providing the transactions table on each backend.
@@ -154,6 +155,15 @@ def test_clv_stats_sample_integration(transactions_table):
     assert sampled_ids <= all_customers
     # Same random_state, same customers -- what a re-rolled random() predicate would fail.
     assert set(clv.sample(n=_SAMPLE_CUSTOMERS).df[cols.customer_id]) == sampled_ids
-    assert set(clv.sample(n=_SUBSET_CUSTOMERS * 2).df[cols.customer_id]) == all_customers
-    # frac=1.0 exercises the modulo/abs predicate rather than the order-by-hash path.
+    # Not the lowest ids: a hash that compiled to a constant would still satisfy every assertion above,
+    # because the customer_id tiebreaker alone yields a stable subset.
+    assert sampled_ids != set(sorted(all_customers)[:_SAMPLE_CUSTOMERS])
+    # frac exercises the modulo/abs predicate rather than the order-by-hash path. A mid-range share
+    # must land strictly inside the population: `bucket < _SAMPLE_BUCKETS` alone is true of any value
+    # the predicate can produce, so frac=1.0 on its own would pass even on an engine selecting nothing.
+    half = set(clv.sample(frac=0.5).df[cols.customer_id])
+    assert set() < half < all_customers
     assert set(clv.sample(frac=1.0).df[cols.customer_id]) == all_customers
+    # A real share pins the predicate's selectivity, which frac=1.0 cannot -- `bucket < 1_000_000`
+    # holds for any bucket, so a dropped ABS() on a signed-hash engine would pass unnoticed.
+    assert 0 < len(clv.sample(frac=0.5).df) < _SUBSET_CUSTOMERS


### PR DESCRIPTION
## Summary

Adds a `sample()` method to `CLVStats` that draws a random subset of customers for model fitting while preserving the ability to score the full population. This enables the fit-on-sample, score-all workflow needed for large customer bases where fitting a Pareto/NBD model on millions of customers is computationally expensive.

## Key Changes

- **New `CLVStats.sample()` method**: Draws customers by deterministic hash of `customer_id` salted with `random_state`. Supports two selection modes:
  - `n`: exact number of customers (yields all if it exceeds population)
  - `frac`: share in (0, 1], decided per customer, so count lands *near* `frac` × population rather than exactly on it
  - Returns a new `CLVStats` instance over the sampled customers, preserving `period` and covariates
  - Draws nest rather than partition: same `random_state` at different `frac` values yields nested subsets; different `random_state` re-draws independently

- **Input validation**: Added `ensure_integer()`, `ensure_positive()`, and `ensure_unit_interval()` validation helpers to `core/validation.py` for argument checking at the API boundary

- **Test coverage**: 
  - 16 new unit tests in `TestCLVStatsSample` covering selection modes, determinism, nesting behavior, covariate preservation, and error cases
  - 1 integration test verifying sampling works correctly on each backend (DuckDB, Postgres, etc.)
  - Reorganized existing tests: moved `test_empty_data_raises_clear_error` and consolidated `test_invalid_period_raises` + `test_observation_period_end_invalid_type_raises` into a single parameterized `test_invalid_construction_argument_raises`

- **Documentation updates**:
  - Updated class docstring to mention `sample()` and clarify that sampled results are lazy
  - Added comprehensive docstring to `sample()` with behavior notes on reproducibility and nesting
  - Updated agent skill references (`clv.md`, `example_clv_stats.py`) with sampling examples and caveats
  - Updated main docs (`docs/experimental/clv.md`) with sampling section explaining `n` vs `frac`, reproducibility per engine/version, and why sampling differs from pre-filtering transactions

## Implementation Details

- Sampling uses the backend's native hash function (compiled to `HASH`, `CHECKSUM`, `ORA_HASH`, `FARM_FINGERPRINT` depending on engine) salted with `random_state` for determinism
- Hash is modulo'd into `_SAMPLE_BUCKETS` (1M) buckets for `frac` resolution; `n` mode orders by bucket + `customer_id` to ensure stable ties
- Bypasses `__init__` to avoid re-running observation-window and attribute validation queries on the already-filtered table
- A sampled row is exactly that customer's row in the full `.df`, so fit and scoring agree; this differs from pre-filtering transactions (which would change `T` and one-hot reference levels)
- Backends without Ibis `hash` rule (SQLite, MySQL, Trino, Athena) raise `OperationNotDefinedError` when `.df` is accessed, not at `sample()` call time, since the expression is lazy

https://claude.ai/code/session_011qHGQobb7XVr5soPX8YmNT