### PR TITLE
build: bump zizmor pre-commit hook to v1.30.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,21 +40,21 @@ jobs:
 
   security-audit:
     name: Dependency Security Audit
-    uses: ./.github/workflows/security-audit.yml
+    uses: $/.github/workflows/security-audit.yml
     permissions:
       contents: read
       security-events: write
 
   bigquery-integration-tests:
     name: BigQuery Integration Tests
-    uses: ./.github/workflows/bigquery-integration.yml
+    uses: $/.github/workflows/bigquery-integration.yml
     secrets:
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
 
   databricks-integration-tests:
     name: Databricks Integration Tests
-    uses: ./.github/workflows/databricks-integration.yml
+    uses: $/.github/workflows/databricks-integration.yml
     secrets:
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
       GCP_INFRA_PROJECT_ID: ${{ secrets.GCP_INFRA_PROJECT_ID }}
@@ -66,11 +66,11 @@ jobs:
 
   pyspark-integration-tests:
     name: PySpark Integration Tests
-    uses: ./.github/workflows/pyspark-integration.yml
+    uses: $/.github/workflows/pyspark-integration.yml
 
   snowflake-integration-tests:
     name: Snowflake Integration Tests
-    uses: ./.github/workflows/snowflake-integration.yml
+    uses: $/.github/workflows/snowflake-integration.yml
     secrets:
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
       GCP_INFRA_PROJECT_ID: ${{ secrets.GCP_INFRA_PROJECT_ID }}
@@ -82,11 +82,11 @@ jobs:
 
   sqlserver-integration-tests:
     name: SQL Server Integration Tests
-    uses: ./.github/workflows/sqlserver-integration.yml
+    uses: $/.github/workflows/sqlserver-integration.yml
 
   oracle-integration-tests:
     name: Oracle Integration Tests
-    uses: ./.github/workflows/oracle-integration.yml
+    uses: $/.github/workflows/oracle-integration.yml
 
   multi-python-tests:
     name: Multi-Python Version Tests
@@ -224,4 +224,4 @@ jobs:
       contents: read
       pages: write
       id-token: write
-    uses: ./.github/workflows/gh-page.yml
+    uses: $/.github/workflows/gh-page.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
         args: ["--config", ".markdownlint.json"]
         exclude: ^\.claude/
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.25.2
+    rev: v1.30.0
     hooks:
       # zizmor enables online audits whenever GH_TOKEN/GITHUB_TOKEN is in the
       # environment, so audit depth would otherwise vary by machine. CI runs this


### PR DESCRIPTION
## Summary

Bumps the zizmor pre-commit hook and adopts the self-repository `uses:` syntax it now recommends.

## Changes

- `.pre-commit-config.yaml`: zizmor hook v1.25.2 → v1.30.0
- `.github/workflows/release.yml`: the eight job-level reusable workflow calls move from `./.github/workflows/…` to `$/.github/workflows/…` (security-audit, bigquery, databricks, pyspark, snowflake, sqlserver, oracle, gh-page)

## Details

zizmor 1.30.0 adds a `self-repository` audit. On the unmodified tree it reports 8 findings (severity low, exit 12), all in `release.yml`; 1.25.2 reported none. The workflow changes here are zizmor's own `--fix` output, not hand-written.

Both syntaxes are valid. `./…` is the older workspace-relative form; [`$/…`](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/) shipped 2026-07-30 and resolves to this repository at the exact commit that is running, so internal references stay consistent even when a caller pins a full-length SHA. GitHub now recommends it for composing actions and reusable workflows within a repository.

Since the hook bump and the workflow edits are coupled, they belong in one change: keeping v1.30.0 while reverting `release.yml` would leave the Pre-Commit job red on every subsequent PR.

## Notes for review

- `$/` requires the Actions runner at 2.336.0+ and is unavailable on GitHub Enterprise Server. Every job here is `runs-on: ubuntu-latest` on GitHub-hosted runners.
- `release.yml` is `workflow_dispatch`-only, so PR CI never parses it — the first live exercise of these eight lines is the next manual release. Worth a maintainer's eye on that basis.
- Verified: `zizmor 1.30.0 --offline` over the repo is clean (exit 0), and the Pre-Commit check passes on this head with the hook at v1.30.0.

https://claude.ai/code/session_01KgnuijMQwboWj45fQPpwbM