### PR TITLE
ci(security): enforce the OSV gate on pull requests

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,21 +1,16 @@
 name: Security Audit
 
-# Scans the resolved dependency lockfile (uv.lock) for known vulnerabilities
-# using OSV-Scanner. Because it reads uv.lock statically, it audits every pinned
-# version across all supported Python versions (3.10-3.14) and platforms.
-# Results are uploaded to GitHub code scanning (Security tab) as SARIF, so a
-# newly-disclosed CVE in a pinned dependency surfaces as a failing check and a
-# code-scanning alert rather than a passive Dependabot alert.
+# Reading uv.lock statically covers every pinned version across all supported
+# Python versions and platforms, so this audit needs no matrix.
 #
-# Suppressions (each with a rationale, and an ignoreUntil expiry where a fix may
-# yet appear) live in osv-scanner.toml at the repo root.
+# Every trigger hard-gates. The path filter means only dependency changes reach
+# it, so an ordinary code pull request is never blocked. Pushes to main also
+# refresh the default-branch code-scanning state.
 #
-# On pull requests the scan runs only when dependencies or this workflow change,
-# and is advisory (results still post to code scanning); pushes to main (same
-# path filter) refresh the default-branch code-scanning state, and manual
-# dispatches and release calls are hard gates. Detection of newly-disclosed CVEs
-# against already-pinned dependencies (with no repo change) is left to Dependabot
-# alerts and security updates, so no scheduled scan is needed here.
+# Newly-disclosed CVEs against unchanged pins are left to Dependabot alerts and
+# security updates, so no scheduled scan is needed. A pass only claims the
+# advisory database was clean at that moment: a pull request can pass and its
+# merge commit still fail.
 
 on:
   pull_request:
@@ -74,13 +69,10 @@ jobs:
           sarif_file: results.sarif
           category: osv-scanner
       - name: Enforce gate
-        # Pull requests are advisory only (results still post to code scanning);
-        # every other trigger is a hard gate. Fail closed: block unless the scan
-        # completed successfully, so a failed, errored, or skipped scan never
-        # passes the gate. !cancelled() (rather than always()) avoids marking a
-        # concurrency-superseded run as failed; a real timeout still blocks
-        # downstream via the job's needs dependency.
-        if: ${{ !cancelled() && github.event_name != 'pull_request' && steps.osv.outcome != 'success' }}
+        # Fail closed on any non-success outcome, including an errored or skipped
+        # scan. !cancelled() rather than always() so a concurrency-superseded run
+        # is not marked failed; a real timeout still blocks downstream via needs.
+        if: ${{ !cancelled() && steps.osv.outcome != 'success' }}
         run: |
           echo "::error::OSV-Scanner did not complete cleanly (vulnerabilities found or scan failed) — see the SARIF results in the Security tab."
           exit 1


### PR DESCRIPTION
## The gap

The `Enforce gate` step excluded itself on pull requests:

```yaml
if: ${{ !cancelled() && github.event_name != 'pull_request' && steps.osv.outcome != 'success' }}
```

Because the scan step carries `continue-on-error: true`, the job reported **success on a PR even when the scan exited 1**. The "OSV-Scanner (uv.lock)" check on a PR was structurally incapable of failing, so a dependency PR carrying a vulnerable pinned version merged green and the failure only appeared on the push to `main` afterwards. That is what happened with #566: the PR check was green, the merge commit's gate was red.

## The change

Drop the `github.event_name` clause, making every trigger a hard gate:

```yaml
if: ${{ !cancelled() && steps.osv.outcome != 'success' }}
```

Nothing else moves. Results still upload to code scanning **before** the gate runs, since the scan step keeps `continue-on-error: true` and the upload step keeps `if: always() && hashFiles('results.sarif') != ''`.

## Why this doesn't block ordinary work

The workflow is already path-filtered to `uv.lock`, `pyproject.toml`, `osv-scanner.toml` and this workflow file. An ordinary code PR never triggers it at all, so it cannot be blocked by this. The PRs that do reach the gate are exactly those changing a pinned version — where a vulnerable lockfile has to be caught before it lands. In practice that is almost entirely Dependabot's PRs.

Where a CVE has no fixed version yet, `osv-scanner.toml` suppressions remain the escape hatch, so this cannot wedge the repo.

## What this does and does not fix

It closes the case where a bump itself carries or retains a vulnerable version.

It does **not** close the race, and it is worth being explicit about that: a green scan is only a claim about the advisory database at that moment, so a PR can pass and its merge commit still fail on a disclosure published in between. That is exactly what happened between #566 and #567 — byte-identical trees, ~28 hours apart, clean then failing. The header comment now says so, since a future reader will otherwise read a green PR gate as a stronger guarantee than it is.

## Deliberately not included

No `schedule:` trigger. The workflow's existing rationale — newly-disclosed CVEs against already-pinned dependencies are delegated to Dependabot alerts and security updates — is retained unchanged.

Worth noting separately for context, not addressed here: the three recent gate failures on `main` (cryptography, snowflake-connector-python, tornado) were all **transitive** packages, none declared in `pyproject.toml`, and none raised by Dependabot. Dependabot's grouped updates work correctly on the direct dependencies. Whether its uv updater raises transitive-only lockfile bumps is a settings/behaviour question best confirmed before adding any redundant scanning.

## Verification

- `python -c "yaml.safe_load(...)"`: parses; triggers unchanged (`pull_request`, `push`, `workflow_call`, `workflow_dispatch`); gate condition reads as intended
- `uv run pre-commit run --all-files`: all 12 hooks pass, including `check-yaml`, `zizmor` and the full pytest suite

One limitation, stated plainly: I verified the condition statically and by reading, **not** by observing the gate fail on a real PR — doing that needs a PR deliberately carrying a vulnerable lockfile. Given the whole point of this change is that a green check was not proof, I would rather flag that than imply otherwise. Happy to demonstrate it end-to-end in a throwaway draft PR if you want it proven before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FychDJrHs5T9Uzfbevf8r8

---
_Generated by [Claude Code](https://claude.ai/code/session_01FychDJrHs5T9Uzfbevf8r8)_